### PR TITLE
feat(models): add foundation for custom PostgreSQL types

### DIFF
--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/ColumnTypeConstant.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/ColumnTypeConstant.java
@@ -99,4 +99,12 @@ public class ColumnTypeConstant {
     
     /** XML type */
     public static final String XML = "xml";
+
+    // Custom PostgreSQL types
+    
+    /** Custom enum type category */
+    public static final String CUSTOM_ENUM = "custom_enum";
+    
+    /** Custom composite object type category */
+    public static final String CUSTOM_COMPOSITE = "custom_composite";
 } 

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/SqlConstant.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/SqlConstant.java
@@ -90,4 +90,46 @@ public class SqlConstant {
               AND cl.relname = ?
               AND n.nspname = ?
             """;
+
+    // Custom PostgreSQL type queries
+    
+    public static final String GET_CUSTOM_ENUM_TYPES = """
+            SELECT t.typname as enum_name,
+                   n.nspname as schema_name,
+                   array_agg(e.enumlabel ORDER BY e.enumsortorder) as enum_values
+            FROM pg_catalog.pg_type t
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+            WHERE n.nspname = ?
+              AND t.typcategory = 'E'
+            GROUP BY t.typname, n.nspname
+            ORDER BY t.typname
+            """;
+    
+    public static final String GET_CUSTOM_COMPOSITE_TYPES = """
+            SELECT t.typname as type_name,
+                   n.nspname as schema_name,
+                   a.attname as attribute_name,
+                   pg_catalog.format_type(a.atttypid, a.atttypmod) as attribute_type,
+                   a.attnum as attribute_order,
+                   CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END as is_nullable
+            FROM pg_catalog.pg_type t
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            JOIN pg_catalog.pg_attribute a ON a.attrelid = t.typrelid
+            WHERE n.nspname = ?
+              AND t.typtype = 'c'
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            ORDER BY t.typname, a.attnum
+            """;
+    
+    public static final String GET_ENUM_VALUES_FOR_TYPE = """
+            SELECT e.enumlabel as value
+            FROM pg_catalog.pg_type t
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+            WHERE t.typname = ?
+              AND n.nspname = ?
+            ORDER BY e.enumsortorder
+            """;
 }

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CompositeTypeAttribute.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CompositeTypeAttribute.java
@@ -1,0 +1,86 @@
+package io.github.excalibase.model;
+
+/**
+ * Information about an attribute of a custom PostgreSQL composite type.
+ * Contains the attribute name, type, order, and nullability.
+ */
+public class CompositeTypeAttribute {
+    private String name;
+    private String type;
+    private int order;
+    private boolean nullable;
+
+    public CompositeTypeAttribute() {
+    }
+
+    public CompositeTypeAttribute(String name, String type, int order, boolean nullable) {
+        this.name = name;
+        this.type = type;
+        this.order = order;
+        this.nullable = nullable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    public void setNullable(boolean nullable) {
+        this.nullable = nullable;
+    }
+
+    @Override
+    public String toString() {
+        return "CompositeTypeAttribute{" +
+                "name='" + name + '\'' +
+                ", type='" + type + '\'' +
+                ", order=" + order +
+                ", nullable=" + nullable +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CompositeTypeAttribute that = (CompositeTypeAttribute) o;
+
+        if (order != that.order) return false;
+        if (nullable != that.nullable) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        return type != null ? type.equals(that.type) : that.type == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + order;
+        result = 31 * result + (nullable ? 1 : 0);
+        return result;
+    }
+} 

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CustomCompositeTypeInfo.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CustomCompositeTypeInfo.java
@@ -1,0 +1,77 @@
+package io.github.excalibase.model;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Information about a custom PostgreSQL composite type.
+ * Contains the type name and its attributes.
+ */
+public class CustomCompositeTypeInfo {
+    private String name;
+    private String schema;
+    private List<CompositeTypeAttribute> attributes;
+
+    public CustomCompositeTypeInfo() {
+        this.attributes = new ArrayList<>();
+    }
+
+    public CustomCompositeTypeInfo(String name, String schema, List<CompositeTypeAttribute> attributes) {
+        this.name = name;
+        this.schema = schema;
+        this.attributes = attributes != null ? new ArrayList<>(attributes) : new ArrayList<>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public List<CompositeTypeAttribute> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<CompositeTypeAttribute> attributes) {
+        this.attributes = attributes != null ? new ArrayList<>(attributes) : new ArrayList<>();
+    }
+
+    @Override
+    public String toString() {
+        return "CustomCompositeTypeInfo{" +
+                "name='" + name + '\'' +
+                ", schema='" + schema + '\'' +
+                ", attributes=" + attributes +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CustomCompositeTypeInfo that = (CustomCompositeTypeInfo) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (schema != null ? !schema.equals(that.schema) : that.schema != null) return false;
+        return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (schema != null ? schema.hashCode() : 0);
+        result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+        return result;
+    }
+} 

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CustomEnumInfo.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/model/CustomEnumInfo.java
@@ -1,0 +1,77 @@
+package io.github.excalibase.model;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Information about a custom PostgreSQL enum type.
+ * Contains the enum name and its possible values.
+ */
+public class CustomEnumInfo {
+    private String name;
+    private String schema;
+    private List<String> values;
+
+    public CustomEnumInfo() {
+        this.values = new ArrayList<>();
+    }
+
+    public CustomEnumInfo(String name, String schema, List<String> values) {
+        this.name = name;
+        this.schema = schema;
+        this.values = values != null ? new ArrayList<>(values) : new ArrayList<>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values != null ? new ArrayList<>(values) : new ArrayList<>();
+    }
+
+    @Override
+    public String toString() {
+        return "CustomEnumInfo{" +
+                "name='" + name + '\'' +
+                ", schema='" + schema + '\'' +
+                ", values=" + values +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CustomEnumInfo that = (CustomEnumInfo) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (schema != null ? !schema.equals(that.schema) : that.schema != null) return false;
+        return values != null ? values.equals(that.values) : that.values == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (schema != null ? schema.hashCode() : 0);
+        result = 31 * result + (values != null ? values.hashCode() : 0);
+        return result;
+    }
+} 

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/generator/IGraphQLSchemaGenerator.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/generator/IGraphQLSchemaGenerator.java
@@ -17,8 +17,11 @@
 package io.github.excalibase.schema.generator;
 
 import graphql.schema.GraphQLSchema;
+import io.github.excalibase.model.CustomCompositeTypeInfo;
+import io.github.excalibase.model.CustomEnumInfo;
 import io.github.excalibase.model.TableInfo;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -62,4 +65,26 @@ public interface IGraphQLSchemaGenerator {
      *                         or unsupported database types
      */
     GraphQLSchema generateSchema(Map<String, TableInfo> tables);
+
+    /**
+     * Generates a complete GraphQL schema from database table metadata with custom types.
+     * 
+     * <p>This method extends the basic schema generation to include support for PostgreSQL
+     * custom enum and composite types. Custom enum types are converted to GraphQL enum types,
+     * and custom composite types are converted to GraphQL object types.</p>
+     * 
+     * @param tables a map where keys are table names and values are TableInfo objects
+     *               containing metadata about each table including columns and foreign keys
+     * @param customEnums list of custom PostgreSQL enum types to include in the schema
+     * @param customComposites list of custom PostgreSQL composite types to include in the schema
+     * @return a complete GraphQL schema ready for use with GraphQL execution engines
+     * @throws RuntimeException if schema generation fails due to invalid table metadata
+     *                         or unsupported database types
+     */
+    default GraphQLSchema generateSchema(Map<String, TableInfo> tables, 
+                                       List<CustomEnumInfo> customEnums,
+                                       List<CustomCompositeTypeInfo> customComposites) {
+        // Default implementation just calls the basic method for backward compatibility
+        return generateSchema(tables);
+    }
 }

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/reflector/IDatabaseSchemaReflector.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/reflector/IDatabaseSchemaReflector.java
@@ -17,70 +17,78 @@
 package io.github.excalibase.schema.reflector;
 
 import io.github.excalibase.model.TableInfo;
+import io.github.excalibase.model.CustomEnumInfo;
+import io.github.excalibase.model.CustomCompositeTypeInfo;
 
 import java.util.Map;
+import java.util.List;
 
 /**
- * Interface for reflecting database schema metadata.
- * 
- * <p>This interface defines the contract for implementations that introspect
- * database schemas to extract table, column, and relationship information.
- * The reflected metadata is used by GraphQL schema generators to create
- * appropriate GraphQL types and resolvers.</p>
- * 
- * <p>Implementations are responsible for:</p>
- * <ul>
- *   <li>Discovering all tables in the configured schema</li>
- *   <li>Extracting column metadata including names, types, and constraints</li>
- *   <li>Identifying foreign key relationships between tables</li>
- *   <li>Filtering tables based on application configuration</li>
- * </ul>
- * 
- * <p>Implementations should be database-specific and annotated with
- * {@link io.github.excalibase.annotation.ExcalibaseService} for proper service lookup.</p>
- *
- * @see TableInfo
- * @see io.github.excalibase.model.ColumnInfo
- * @see io.github.excalibase.model.ForeignKeyInfo
- * @see io.github.excalibase.annotation.ExcalibaseService
+ * Interface for database schema reflection.
+ * Implementations should provide methods to extract table structure, relationships,
+ * and custom types from the database.
  */
 public interface IDatabaseSchemaReflector {
-    
+
     /**
-     * Reflects the database schema and returns table metadata.
-     * 
-     * <p>This method connects to the database and extracts comprehensive metadata
-     * about all tables within the configured schema. The returned map contains
-     * complete information about each table including its columns, data types,
-     * constraints, and foreign key relationships.</p>
-     * 
-     * @return a map where keys are table names and values are TableInfo objects
-     *         containing complete metadata for each table
-     * @throws RuntimeException if database connection fails or schema reflection
-     *                         encounters errors
-     * @throws io.github.excalibase.exception.EmptySchemaException if no tables
-     *                         are found in the configured schema
+     * Reflects the entire database schema and returns a map of table information.
+     * This method should cache results for performance.
+     *
+     * @return A map where keys are table names and values are TableInfo objects
      */
     Map<String, TableInfo> reflectSchema();
-    
+
     /**
-     * Clears the schema cache for all schemas.
-     * This method should be called when database schema changes are detected.
-     * 
-     * <p>Implementations should clear any cached schema metadata to ensure
-     * that subsequent calls to {@link #reflectSchema()} will fetch fresh
-     * data from the database.</p>
+     * Reflects and returns information about custom enum types in the schema.
+     * This includes user-defined enum types with their possible values.
+     *
+     * @return A list of CustomEnumInfo objects representing all custom enum types
+     */
+    List<CustomEnumInfo> getCustomEnumTypes();
+
+    /**
+     * Reflects and returns information about custom enum types in the specified schema.
+     * This includes user-defined enum types with their possible values.
+     *
+     * @param schema The schema name to search for custom enum types
+     * @return A list of CustomEnumInfo objects representing all custom enum types in the schema
+     */
+    List<CustomEnumInfo> getCustomEnumTypes(String schema);
+
+    /**
+     * Reflects and returns information about custom composite types in the schema.
+     * This includes user-defined composite (object) types with their attributes.
+     *
+     * @return A list of CustomCompositeTypeInfo objects representing all custom composite types
+     */
+    List<CustomCompositeTypeInfo> getCustomCompositeTypes();
+
+    /**
+     * Reflects and returns information about custom composite types in the specified schema.
+     * This includes user-defined composite (object) types with their attributes.
+     *
+     * @param schema The schema name to search for custom composite types
+     * @return A list of CustomCompositeTypeInfo objects representing all custom composite types in the schema
+     */
+    List<CustomCompositeTypeInfo> getCustomCompositeTypes(String schema);
+
+    /**
+     * Gets the values for a specific enum type.
+     *
+     * @param enumName The name of the enum type
+     * @param schema The schema name where the enum is defined
+     * @return A list of string values for the enum type
+     */
+    List<String> getEnumValues(String enumName, String schema);
+
+    /**
+     * Clears all cached schema information.
      */
     void clearCache();
-    
+
     /**
-     * Clears the schema cache for a specific schema.
-     * This method should be called when database schema changes are detected for a specific schema.
-     * 
-     * <p>Implementations should clear cached schema metadata for the specified schema
-     * to ensure that subsequent calls to {@link #reflectSchema()} will fetch fresh
-     * data from the database for that schema.</p>
-     * 
+     * Clears cached schema information for a specific schema.
+     *
      * @param schema The schema name to clear from cache
      */
     void clearCache(String schema);

--- a/modules/excalibase-graphql-starter/src/test/groovy/io/github/excalibase/constant/PostgresTypeOperatorTest.groovy
+++ b/modules/excalibase-graphql-starter/src/test/groovy/io/github/excalibase/constant/PostgresTypeOperatorTest.groovy
@@ -105,7 +105,7 @@ class PostgresTypeOperatorTest extends Specification {
 
     def "should correctly identify binary/network types"() {
         expect:
-        PostgresTypeOperator.isBinaryOrNetworkType(type) == expected
+        PostgresTypeOperator.isNetworkType(type) == expected
 
         where:
         type        | expected
@@ -160,6 +160,98 @@ class PostgresTypeOperatorTest extends Specification {
         "text"        | false
         null          | false
         ""            | false
+    }
+
+    def "should correctly identify custom enum types"() {
+        expect:
+        PostgresTypeOperator.isCustomEnumType(type) == expected
+
+        where:
+        type            | expected
+        "order_status"  | true
+        "user_role"     | true
+        "priority_level"| true
+        "custom_type"   | true
+        "varchar"       | false
+        "text"          | false
+        "integer"       | false
+        "boolean"       | false
+        "json"          | false
+        "timestamp"     | false
+        "uuid"          | false
+        "inet"          | false
+        "xml"           | false
+        null            | false
+        ""              | false
+    }
+
+    def "should correctly identify custom composite types"() {
+        expect:
+        PostgresTypeOperator.isCustomCompositeType(type) == expected
+
+        where:
+        type                | expected
+        "address"           | true
+        "contact_info"      | true
+        "product_dimensions"| true
+        "custom_object"     | true
+        "varchar"           | false
+        "text"              | false
+        "integer"           | false
+        "boolean"           | false
+        "json"              | false
+        "timestamp"         | false
+        "uuid"              | false
+        "inet"              | false
+        "xml"               | false
+        null                | false
+        ""                  | false
+    }
+
+    def "should correctly identify custom enum array types"() {
+        expect:
+        PostgresTypeOperator.isCustomEnumType(type) == expected
+
+        where:
+        type                 | expected
+        "order_status[]"     | true
+        "user_role[]"        | true
+        "priority_level[]"   | true
+        "varchar[]"          | false
+        "integer[]"          | false
+        "boolean[]"          | false
+        null                 | false
+    }
+
+    def "should correctly identify custom composite array types"() {
+        expect:
+        PostgresTypeOperator.isCustomCompositeType(type) == expected
+
+        where:
+        type                     | expected
+        "address[]"              | true
+        "contact_info[]"         | true
+        "product_dimensions[]"   | true
+        "varchar[]"              | false
+        "integer[]"              | false
+        "boolean[]"              | false
+        null                     | false
+    }
+
+    def "should extract base type from array types"() {
+        expect:
+        PostgresTypeOperator.getBaseArrayType(type) == expected
+
+        where:
+        type                 | expected
+        "integer[]"          | "integer"
+        "varchar[]"          | "varchar"
+        "order_status[]"     | "order_status"
+        "address[]"          | "address"
+        "integer"            | "integer"
+        "varchar"            | "varchar"
+        "order_status"       | "order_status"
+        null                 | null
     }
 
     def "should handle case insensitivity correctly"() {


### PR DESCRIPTION
- Add CustomEnumInfo model for PostgreSQL enum types
- Add CustomCompositeTypeInfo model for composite types
- Add CompositeTypeAttribute for composite type attributes
- Update ColumnTypeConstant with custom type constants
- Extend PostgresTypeOperator with custom type operators
- Add SQL constants for custom type queries
- Update IDatabaseSchemaReflector interface for custom types
- Update IGraphQLSchemaGenerator interface for custom types
- Add comprehensive tests for PostgresTypeOperator

This foundation enables custom enum and composite type support in PostgreSQL GraphQL schema generation.