### PR TITLE
  Add comprehensive BIT type support for PostgreSQL GraphQL integration

### DIFF
--- a/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/constant/PostgresTypeOperator.java
+++ b/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/constant/PostgresTypeOperator.java
@@ -7,30 +7,32 @@ import io.github.excalibase.constant.ColumnTypeConstant;
  * Provides centralized logic for determining PostgreSQL data types.
  */
 public class PostgresTypeOperator {
-    
+
     private PostgresTypeOperator() {
         // Utility class - prevent instantiation
     }
-    
+
     /**
      * Checks if the given type is an integer type (excluding interval)
+     *
      * @param type the database type to check
      * @return true if it's an integer type
      */
     public static boolean isIntegerType(String type) {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
-        return (lowerType.equals(ColumnTypeConstant.INT) || lowerType.equals("int2") || 
-                lowerType.equals("int4") || lowerType.equals("int8") ||
-                lowerType.equals("integer") || lowerType.equals(ColumnTypeConstant.BIGINT) || 
+        return (lowerType.equals(ColumnTypeConstant.INT) || lowerType.equals(ColumnTypeConstant.INT2) ||
+                lowerType.equals(ColumnTypeConstant.INT4) || lowerType.equals(ColumnTypeConstant.INT8) ||
+                lowerType.equals(ColumnTypeConstant.INTEGER) || lowerType.equals(ColumnTypeConstant.BIGINT) ||
                 lowerType.equals(ColumnTypeConstant.SMALLINT) || lowerType.equals(ColumnTypeConstant.SERIAL) ||
-                lowerType.equals("serial2") || lowerType.equals("serial4") ||
-                lowerType.equals("serial8") || lowerType.equals("smallserial") ||
+                lowerType.equals(ColumnTypeConstant.SERIAL2) || lowerType.equals(ColumnTypeConstant.SERIAL4) ||
+                lowerType.equals(ColumnTypeConstant.SERIAL8) || lowerType.equals(ColumnTypeConstant.SMALLSERIAL) ||
                 lowerType.equals(ColumnTypeConstant.BIGSERIAL));
     }
-    
+
     /**
      * Checks if the given type is a floating-point numeric type
+     *
      * @param type the database type to check
      * @return true if it's a floating-point type
      */
@@ -38,13 +40,14 @@ public class PostgresTypeOperator {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.NUMERIC) || lowerType.contains(ColumnTypeConstant.DECIMAL) ||
-               lowerType.contains(ColumnTypeConstant.REAL) || lowerType.contains(ColumnTypeConstant.DOUBLE_PRECISION) ||
-               lowerType.contains(ColumnTypeConstant.FLOAT) || 
-               lowerType.contains(ColumnTypeConstant.DOUBLE);
+                lowerType.contains(ColumnTypeConstant.REAL) || lowerType.contains(ColumnTypeConstant.DOUBLE_PRECISION) ||
+                lowerType.contains(ColumnTypeConstant.FLOAT) || lowerType.contains(ColumnTypeConstant.FLOAT4) ||
+                lowerType.contains(ColumnTypeConstant.FLOAT8) || lowerType.contains(ColumnTypeConstant.DOUBLE);
     }
-    
+
     /**
      * Checks if the given type is a boolean type
+     *
      * @param type the database type to check
      * @return true if it's a boolean type
      */
@@ -53,9 +56,10 @@ public class PostgresTypeOperator {
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.BOOLEAN) || lowerType.contains(ColumnTypeConstant.BOOL);
     }
-    
+
     /**
      * Checks if the given type is a JSON type (JSON or JSONB)
+     *
      * @param type the database type to check
      * @return true if it's a JSON type
      */
@@ -64,9 +68,10 @@ public class PostgresTypeOperator {
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.JSON) || lowerType.contains(ColumnTypeConstant.JSONB);
     }
-    
+
     /**
      * Checks if the given type is a date/time type
+     *
      * @param type the database type to check
      * @return true if it's a date/time type
      */
@@ -74,12 +79,13 @@ public class PostgresTypeOperator {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.TIMESTAMP) || lowerType.contains(ColumnTypeConstant.TIMESTAMPTZ) ||
-               lowerType.contains(ColumnTypeConstant.DATE) || lowerType.contains(ColumnTypeConstant.TIME) ||
-               lowerType.contains(ColumnTypeConstant.TIMETZ) || lowerType.contains(ColumnTypeConstant.INTERVAL);
+                lowerType.contains(ColumnTypeConstant.DATE) || lowerType.contains(ColumnTypeConstant.TIME) ||
+                lowerType.contains(ColumnTypeConstant.TIMETZ) || lowerType.contains(ColumnTypeConstant.INTERVAL);
     }
-    
+
     /**
      * Checks if the given type is a UUID type
+     *
      * @param type the database type to check
      * @return true if it's a UUID type
      */
@@ -88,33 +94,49 @@ public class PostgresTypeOperator {
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.UUID);
     }
-    
+
     /**
      * Checks if the given type is a network type (INET, CIDR, etc.)
+     *
      * @param type the database type to check
      * @return true if it's a network type
      */
     public static boolean isNetworkType(String type) {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
-        return lowerType.contains(ColumnTypeConstant.BYTEA) || lowerType.contains(ColumnTypeConstant.INET) ||
-               lowerType.contains(ColumnTypeConstant.CIDR) || lowerType.contains(ColumnTypeConstant.MACADDR) ||
-               lowerType.contains(ColumnTypeConstant.MACADDR8);
+        return lowerType.contains(ColumnTypeConstant.INET) ||
+                lowerType.contains(ColumnTypeConstant.CIDR) || lowerType.contains(ColumnTypeConstant.MACADDR) ||
+                lowerType.contains(ColumnTypeConstant.MACADDR8);
     }
-    
+
+    /**
+     * Checks if the given type is a binary type
+     *
+     * @param type the database type to check
+     * @return true if it's a binary type
+     */
+    public static boolean isBinaryType(String type) {
+        if (type == null) return false;
+        String lowerType = type.toLowerCase();
+        return lowerType.contains(ColumnTypeConstant.BYTEA);
+    }
+
     /**
      * Checks if the given type is a bit string type
+     *
      * @param type the database type to check
      * @return true if it's a bit string type
      */
     public static boolean isBitType(String type) {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
-        return lowerType.contains(ColumnTypeConstant.BIT) || lowerType.contains(ColumnTypeConstant.VARBIT);
+        return lowerType.contains(ColumnTypeConstant.BIT) || lowerType.contains(ColumnTypeConstant.VARBIT) || 
+               lowerType.contains(ColumnTypeConstant.BIT_VARYING);
     }
-    
+
     /**
      * Checks if the given type is an XML type
+     *
      * @param type the database type to check
      * @return true if it's an XML type
      */
@@ -123,9 +145,10 @@ public class PostgresTypeOperator {
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.XML);
     }
-    
+
     /**
      * Checks if the given type is an array type
+     *
      * @param type the database type to check
      * @return true if it's an array type
      */
@@ -137,6 +160,7 @@ public class PostgresTypeOperator {
 
     /**
      * Gets the base type from an array type
+     *
      * @param arrayType the array type (e.g., "integer[]")
      * @return the base type (e.g., "integer")
      */
@@ -146,29 +170,10 @@ public class PostgresTypeOperator {
         }
         return arrayType.replace(ColumnTypeConstant.ARRAY_SUFFIX, "");
     }
-    
-    /**
-     * Checks if the given type is a built-in PostgreSQL type
-     * @param type the database type to check
-     * @return true if it's a built-in type
-     */
-    public static boolean isBuiltInType(String type) {
-        if (type == null) return false;
-        
-        // For array types, check if the base type is built-in
-        if (isArrayType(type)) {
-            String baseType = getBaseArrayType(type);
-            return isBuiltInType(baseType);
-        }
-        
-        return isIntegerType(type) || isFloatingPointType(type) || isBooleanType(type) ||
-               isJsonType(type) || isDateTimeType(type) || isUuidType(type) ||
-               isNetworkType(type) || isBitType(type) || isXmlType(type) ||
-               isTextType(type);
-    }
-    
+
     /**
      * Checks if the given type is a text type
+     *
      * @param type the database type to check
      * @return true if it's a text type
      */
@@ -176,31 +181,6 @@ public class PostgresTypeOperator {
         if (type == null) return false;
         String lowerType = type.toLowerCase();
         return lowerType.contains(ColumnTypeConstant.VARCHAR) || lowerType.contains(ColumnTypeConstant.TEXT) ||
-               lowerType.contains(ColumnTypeConstant.CHAR);
+                lowerType.contains(ColumnTypeConstant.CHAR);
     }
-    
-    /**
-     * Gets the category of a PostgreSQL type
-     * @param type the database type to categorize
-     * @return the type category
-     */
-    public static String getTypeCategory(String type) {
-        if (type == null) return "unknown";
-        
-        // Check array type first since it takes precedence
-        if (isArrayType(type)) return "array";
-        
-        if (isIntegerType(type)) return "integer";
-        if (isFloatingPointType(type)) return "numeric";
-        if (isBooleanType(type)) return "boolean";
-        if (isTextType(type)) return "text";
-        if (isDateTimeType(type)) return "datetime";
-        if (isJsonType(type)) return "json";
-        if (isUuidType(type)) return "uuid";
-        if (isNetworkType(type)) return "network";
-        if (isBitType(type)) return "bit";
-        if (isXmlType(type)) return "xml";
-        
-        return "unknown";
-    }
-} 
+}

--- a/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/generator/PostgresGraphQLSchemaGeneratorImplement.java
+++ b/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/generator/PostgresGraphQLSchemaGeneratorImplement.java
@@ -1035,8 +1035,8 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
         log.debug("Request db type: {}", type);
 
         // Handle array types
-        if (type.contains(ColumnTypeConstant.ARRAY_SUFFIX)) {
-            String baseType = type.replace(ColumnTypeConstant.ARRAY_SUFFIX, "");
+        if (PostgresTypeOperator.isArrayType(type)) {
+            String baseType = PostgresTypeOperator.getBaseArrayType(type);
             GraphQLOutputType elementType = mapDatabaseTypeToGraphQLType(baseType);
             return new GraphQLList(elementType);
         }
@@ -1062,7 +1062,7 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
         }
 
         // UUID types
-        else if (type.contains(ColumnTypeConstant.UUID)) {
+        else if (PostgresTypeOperator.isUuidType(type)) {
             return GraphQLID;
         }
 
@@ -1072,19 +1072,17 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
         }
 
         // Binary and network types
-        else if (type.contains(ColumnTypeConstant.BYTEA) || type.contains(ColumnTypeConstant.INET) ||
-                type.contains(ColumnTypeConstant.CIDR) || type.contains(ColumnTypeConstant.MACADDR) ||
-                type.contains(ColumnTypeConstant.MACADDR8)) {
+        else if (PostgresTypeOperator.isBinaryType(type) || PostgresTypeOperator.isNetworkType(type)) {
             return GraphQLString;
         }
 
         // Bit types
-        else if (type.contains(ColumnTypeConstant.BIT) || type.contains(ColumnTypeConstant.VARBIT)) {
+        else if (PostgresTypeOperator.isBitType(type)) {
             return GraphQLString;
         }
 
         // XML type
-        else if (type.contains(ColumnTypeConstant.XML)) {
+        else if (PostgresTypeOperator.isXmlType(type)) {
             return GraphQLString;
         }
 
@@ -1437,20 +1435,18 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
         String type = dbType.toLowerCase();
 
         // Handle array types - use the base type's filter
-        if (type.contains(ColumnTypeConstant.ARRAY_SUFFIX)) {
-            String baseType = type.replace(ColumnTypeConstant.ARRAY_SUFFIX, "");
+        if (PostgresTypeOperator.isArrayType(type)) {
+            String baseType = PostgresTypeOperator.getBaseArrayType(type);
             return getFilterTypeNameForColumn(baseType);
         }
 
         // JSON/JSONB types
-        if (type.contains(ColumnTypeConstant.JSON) || type.contains(ColumnTypeConstant.JSONB)) {
+        if (PostgresTypeOperator.isJsonType(type)) {
             return "JSONFilter";
         }
 
         // Date/Time types (including enhanced ones)
-        else if (type.contains(ColumnTypeConstant.TIMESTAMP) || type.contains(ColumnTypeConstant.TIMESTAMPTZ) ||
-                type.contains(ColumnTypeConstant.DATE) || type.contains(ColumnTypeConstant.TIME) ||
-                type.contains(ColumnTypeConstant.TIMETZ) || type.contains(ColumnTypeConstant.INTERVAL)) {
+        else if (PostgresTypeOperator.isDateTimeType(type)) {
             return "DateTimeFilter";
         }
 
@@ -1558,9 +1554,9 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
                                                            Map<String, GraphQLEnumType> customEnumTypes,
                                                            Map<String, GraphQLObjectType> customCompositeTypes) {
         // Handle array types first
-        if (type.contains(ColumnTypeConstant.ARRAY_SUFFIX)) {
-            String baseType = type.replace(ColumnTypeConstant.ARRAY_SUFFIX, "");
-            String baseOriginalType = originalType != null ? originalType.replace(ColumnTypeConstant.ARRAY_SUFFIX, "") : null;
+        if (PostgresTypeOperator.isArrayType(type)) {
+            String baseType = PostgresTypeOperator.getBaseArrayType(type);
+            String baseOriginalType = originalType != null ? PostgresTypeOperator.getBaseArrayType(originalType) : null;
             GraphQLOutputType elementType = mapDatabaseTypeToGraphQLType(baseType, baseOriginalType, customEnumTypes, customCompositeTypes);
             return new GraphQLList(elementType);
         }
@@ -1622,9 +1618,9 @@ public class PostgresGraphQLSchemaGeneratorImplement implements IGraphQLSchemaGe
                                                               Map<String, GraphQLEnumType> customEnumTypes,
                                                               Map<String, GraphQLObjectType> customCompositeTypes) {
         // Handle array types first
-        if (type.contains(ColumnTypeConstant.ARRAY_SUFFIX)) {
-            String baseType = type.replace(ColumnTypeConstant.ARRAY_SUFFIX, "");
-            String baseOriginalType = originalType != null ? originalType.replace(ColumnTypeConstant.ARRAY_SUFFIX, "") : null;
+        if (PostgresTypeOperator.isArrayType(type)) {
+            String baseType = PostgresTypeOperator.getBaseArrayType(type);
+            String baseOriginalType = originalType != null ? PostgresTypeOperator.getBaseArrayType(originalType) : null;
             GraphQLInputType elementType = mapDatabaseTypeToGraphQLInputType(baseType, baseOriginalType, customEnumTypes, customCompositeTypes);
             return new GraphQLList(elementType);
         }

--- a/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/util/PostgresSchemaHelper.java
+++ b/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/util/PostgresSchemaHelper.java
@@ -22,6 +22,7 @@ import io.github.excalibase.exception.NotFoundException;
 import io.github.excalibase.model.ColumnInfo;
 import io.github.excalibase.model.ForeignKeyInfo;
 import io.github.excalibase.model.TableInfo;
+import io.github.excalibase.postgres.constant.PostgresTypeOperator;
 import io.github.excalibase.schema.reflector.IDatabaseSchemaReflector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,8 +101,7 @@ public class PostgresSchemaHelper {
     public void addRequiredTimestampFields(TableInfo tableInfo, Map<String, Object> fields) {
         Set<String> requiredTimestampFields = tableInfo.getColumns().stream()
             .filter(col -> !col.isNullable() && 
-                          (col.getType().toLowerCase().contains(ColumnTypeConstant.TIMESTAMP) || 
-                           col.getType().toLowerCase().contains(ColumnTypeConstant.DATE)))
+                          PostgresTypeOperator.isDateTimeType(col.getType().toLowerCase()))
             .map(ColumnInfo::getName)
             .collect(Collectors.toSet());
         

--- a/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/util/PostgresSqlBuilder.java
+++ b/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/util/PostgresSqlBuilder.java
@@ -248,16 +248,18 @@ public class PostgresSqlBuilder {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else if (columnType.contains(ColumnTypeConstant.INTERVAL)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.INTERVAL;
-        } else if (columnType.contains(ColumnTypeConstant.JSON)) {
+        } else if (PostgresTypeOperator.isJsonType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.INET) || columnType.contains(ColumnTypeConstant.CIDR) || columnType.contains(ColumnTypeConstant.MACADDR)) {
+        } else if (PostgresTypeOperator.isNetworkType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.TIMESTAMP) || columnType.contains(ColumnTypeConstant.TIME)) {
+        } else if (PostgresTypeOperator.isDateTimeType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.XML)) {
+        } else if (PostgresTypeOperator.isXmlType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.XML;
-        } else if (columnType.contains(ColumnTypeConstant.BYTEA)) {
+        } else if (PostgresTypeOperator.isBinaryType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.BYTEA;
+        } else if (PostgresTypeOperator.isBitType(columnType)) {
+            return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else if (typeConverter.isCustomEnumType(columnType)) {
             return ":" + field + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else if (typeConverter.isCustomCompositeType(columnType)) {
@@ -275,16 +277,18 @@ public class PostgresSqlBuilder {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else if (columnType.contains(ColumnTypeConstant.INTERVAL)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.INTERVAL;
-        } else if (columnType.contains(ColumnTypeConstant.JSON)) {
+        } else if (PostgresTypeOperator.isJsonType(columnType)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.INET) || columnType.contains(ColumnTypeConstant.CIDR) || columnType.contains(ColumnTypeConstant.MACADDR)) {
+        } else if (PostgresTypeOperator.isNetworkType(columnType)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.TIMESTAMP) || columnType.contains(ColumnTypeConstant.TIME)) {
+        } else if (PostgresTypeOperator.isDateTimeType(columnType)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.XML)) {
+        } else if (PostgresTypeOperator.isXmlType(columnType)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.XML;
-        } else if (columnType.contains(ColumnTypeConstant.BYTEA)) {
+        } else if (PostgresTypeOperator.isBinaryType(columnType)) {
             return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.BYTEA;
+        } else if (PostgresTypeOperator.isBitType(columnType)) {
+            return ":" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else {
             return ":" + paramName;
         }
@@ -430,7 +434,7 @@ public class PostgresSqlBuilder {
         if (isInterval) {
             typeConverter.addTypedParameter(paramSource, paramName, value, columnType);
             return quotedColumnName + " " + operator + " :" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.INTERVAL;
-        } else if (columnType != null && (columnType.contains(ColumnTypeConstant.TIMESTAMP) || columnType.contains(ColumnTypeConstant.TIME))) {
+        } else if (columnType != null && PostgresTypeOperator.isDateTimeType(columnType)) {
             typeConverter.addTypedParameter(paramSource, paramName, value, columnType);
             return quotedColumnName + " " + operator + " :" + paramName + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else {
@@ -441,13 +445,13 @@ public class PostgresSqlBuilder {
 
     private String buildContainsCondition(String quotedColumnName, String paramName, Object value, String columnType, 
                                         MapSqlParameterSource paramSource) {
-        if (columnType != null && (columnType.toLowerCase().contains(ColumnTypeConstant.JSON))) {
+        if (columnType != null && PostgresTypeOperator.isJsonType(columnType)) {
             paramSource.addValue(paramName, "%" + value + "%");
             return quotedColumnName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " LIKE :" + paramName;
-        } else if (columnType != null && columnType.toLowerCase().contains(ColumnTypeConstant.XML)) {
+        } else if (columnType != null && PostgresTypeOperator.isXmlType(columnType)) {
             paramSource.addValue(paramName, "%" + value + "%");
             return quotedColumnName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " LIKE :" + paramName;
-        } else if (columnType != null && (columnType.contains(ColumnTypeConstant.INET) || columnType.contains(ColumnTypeConstant.CIDR) || columnType.contains(ColumnTypeConstant.MACADDR))) {
+        } else if (columnType != null && PostgresTypeOperator.isNetworkType(columnType)) {
             paramSource.addValue(paramName, "%" + value + "%");
             return quotedColumnName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + paramName;
         } else {
@@ -458,7 +462,7 @@ public class PostgresSqlBuilder {
 
     private String buildStartsWithCondition(String quotedColumnName, String paramName, Object value, String columnType, 
                                           MapSqlParameterSource paramSource) {
-        if (columnType != null && (columnType.contains("inet") || columnType.contains("cidr") || columnType.contains("macaddr"))) {
+        if (columnType != null && PostgresTypeOperator.isNetworkType(columnType)) {
             paramSource.addValue(paramName, value + "%");
             return quotedColumnName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + paramName;
         } else {
@@ -469,7 +473,7 @@ public class PostgresSqlBuilder {
 
     private String buildEndsWithCondition(String quotedColumnName, String paramName, Object value, String columnType, 
                                         MapSqlParameterSource paramSource) {
-        if (columnType != null && (columnType.contains("inet") || columnType.contains("cidr") || columnType.contains("macaddr"))) {
+        if (columnType != null && PostgresTypeOperator.isNetworkType(columnType)) {
             paramSource.addValue(paramName, "%" + value);
             return quotedColumnName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + paramName;
         } else {
@@ -562,13 +566,13 @@ public class PostgresSqlBuilder {
 
     private String buildLegacyContainsCondition(String quotedFieldName, String key, Object value, String fieldColumnType, 
                                               MapSqlParameterSource paramSource) {
-        if (fieldColumnType.contains("json")) {
+        if (PostgresTypeOperator.isJsonType(fieldColumnType)) {
             paramSource.addValue(key, "%" + value + "%");
             return quotedFieldName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " LIKE :" + key;
-        } else if (fieldColumnType.contains("xml")) {
+        } else if (PostgresTypeOperator.isXmlType(fieldColumnType)) {
             paramSource.addValue(key, "%" + value + "%");
             return quotedFieldName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " LIKE :" + key;
-        } else if (fieldColumnType.contains("inet") || fieldColumnType.contains("cidr") || fieldColumnType.contains("macaddr")) {
+        } else if (PostgresTypeOperator.isNetworkType(fieldColumnType)) {
             paramSource.addValue(key, "%" + value + "%");
             return quotedFieldName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + key;
         } else {
@@ -579,7 +583,7 @@ public class PostgresSqlBuilder {
 
     private String buildLegacyStartsWithCondition(String quotedFieldName, String key, Object value, String fieldColumnType, 
                                                 MapSqlParameterSource paramSource) {
-        if (fieldColumnType.contains("inet") || fieldColumnType.contains("cidr") || fieldColumnType.contains("macaddr") || fieldColumnType.contains("xml")) {
+        if (PostgresTypeOperator.isNetworkType(fieldColumnType) || PostgresTypeOperator.isXmlType(fieldColumnType)) {
             paramSource.addValue(key, value + "%");
             return quotedFieldName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + key;
         } else {
@@ -590,7 +594,7 @@ public class PostgresSqlBuilder {
 
     private String buildLegacyEndsWithCondition(String quotedFieldName, String key, Object value, String fieldColumnType, 
                                               MapSqlParameterSource paramSource) {
-        if (fieldColumnType.contains("inet") || fieldColumnType.contains("cidr") || fieldColumnType.contains("macaddr") || fieldColumnType.contains("xml")) {
+        if (PostgresTypeOperator.isNetworkType(fieldColumnType) || PostgresTypeOperator.isXmlType(fieldColumnType)) {
             paramSource.addValue(key, "%" + value);
             return quotedFieldName + PostgresSqlSyntaxConstant.CAST_TO_TEXT + " ILIKE :" + key;
         } else {
@@ -604,7 +608,7 @@ public class PostgresSqlBuilder {
         if (fieldColumnType.contains(ColumnTypeConstant.INTERVAL)) {
             paramSource.addValue(key, value.toString());
             return quotedFieldName + " " + operator + " :" + key + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.INTERVAL;
-        } else if (fieldColumnType.contains(ColumnTypeConstant.TIMESTAMP) || fieldColumnType.contains(ColumnTypeConstant.TIME)) {
+        } else if (PostgresTypeOperator.isDateTimeType(fieldColumnType)) {
             paramSource.addValue(key, value.toString());
             return quotedFieldName + " " + operator + " :" + key + PostgresSqlSyntaxConstant.CAST_OPERATOR + fieldColumnType;
         } else {
@@ -615,7 +619,7 @@ public class PostgresSqlBuilder {
 
     private String buildBasicEqualityCondition(String quotedKey, String key, Object value, String columnType, 
                                              MapSqlParameterSource paramSource) {
-        if (columnType.contains(ColumnTypeConstant.UUID) && value instanceof String) {
+        if (PostgresTypeOperator.isUuidType(columnType) && value instanceof String) {
             try {
                 java.util.UUID uuid = java.util.UUID.fromString((String) value);
                 paramSource.addValue(key, uuid);
@@ -627,10 +631,10 @@ public class PostgresSqlBuilder {
         } else if (columnType.contains(ColumnTypeConstant.INTERVAL)) {
             paramSource.addValue(key, value.toString());
             return quotedKey + PostgresSqlSyntaxConstant.EQUALS_PARAM + key + PostgresSqlSyntaxConstant.CAST_OPERATOR + ColumnTypeConstant.INTERVAL;
-        } else if (columnType.contains(ColumnTypeConstant.INET) || columnType.contains(ColumnTypeConstant.CIDR) || columnType.contains(ColumnTypeConstant.MACADDR)) {
+        } else if (PostgresTypeOperator.isNetworkType(columnType)) {
             paramSource.addValue(key, value.toString());
             return quotedKey + PostgresSqlSyntaxConstant.EQUALS_PARAM + key + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
-        } else if (columnType.contains(ColumnTypeConstant.TIMESTAMP) || columnType.contains(ColumnTypeConstant.TIME)) {
+        } else if (PostgresTypeOperator.isDateTimeType(columnType)) {
             paramSource.addValue(key, value.toString());
             return quotedKey + PostgresSqlSyntaxConstant.EQUALS_PARAM + key + PostgresSqlSyntaxConstant.CAST_OPERATOR + columnType;
         } else if (PostgresTypeOperator.isIntegerType(columnType) || PostgresTypeOperator.isFloatingPointType(columnType)) {
@@ -651,7 +655,7 @@ public class PostgresSqlBuilder {
                 if (PostgresTypeOperator.isIntegerType(columnType)) {
                     int numericValue = Integer.parseInt((String) value);
                     paramSource.addValue(key, numericValue);
-                } else if (columnType.contains(ColumnTypeConstant.BIGINT)) {
+                } else if (PostgresTypeOperator.isIntegerType(columnType) && columnType.contains(ColumnTypeConstant.BIGINT)) {
                     long numericValue = Long.parseLong((String) value);
                     paramSource.addValue(key, numericValue);
                 } else {

--- a/modules/excalibase-graphql-postgres/src/test/groovy/io/github/excalibase/postgres/constant/PostgresTypeOperatorTest.groovy
+++ b/modules/excalibase-graphql-postgres/src/test/groovy/io/github/excalibase/postgres/constant/PostgresTypeOperatorTest.groovy
@@ -112,17 +112,32 @@ class PostgresTypeOperatorTest extends Specification {
         ""        | false
     }
 
-    def "should correctly identify binary/network types"() {
+    def "should correctly identify network types"() {
         expect:
         PostgresTypeOperator.isNetworkType(type) == expected
 
         where:
         type        | expected
-        "bytea"     | true
         "inet"      | true
         "cidr"      | true
         "macaddr"   | true
         "macaddr8"  | true
+        "text"      | false
+        "int"       | false
+        "bytea"     | false  // bytea is binary, not network
+        null        | false
+        ""          | false
+    }
+
+    def "should correctly identify binary types"() {
+        expect:
+        PostgresTypeOperator.isBinaryType(type) == expected
+
+        where:
+        type        | expected
+        "bytea"     | true
+        "inet"      | false  // inet is network, not binary
+        "cidr"      | false  // cidr is network, not binary
         "text"      | false
         "int"       | false
         null        | false
@@ -254,46 +269,4 @@ class PostgresTypeOperatorTest extends Specification {
         ""                    | false
     }
 
-    def "should categorize types correctly"() {
-        expect:
-        PostgresTypeOperator.getTypeCategory(type) == expected
-
-        where:
-        type                  | expected
-        "int"                 | "integer"
-        "bigint"              | "integer"
-        "numeric"             | "numeric"
-        "double precision"    | "numeric"
-        "boolean"             | "boolean"
-        "text"                | "text"
-        "varchar(255)"        | "text"
-        "timestamp"           | "datetime"
-        "date"                | "datetime"
-        "json"                | "json"
-        "jsonb"               | "json"
-        "uuid"                | "uuid"
-        "inet"                | "network"
-        "bit"                 | "bit"
-        "xml"                 | "xml"
-        "int[]"               | "array"
-        "unknown_type"        | "unknown"
-        null                  | "unknown"
-    }
-
-    def "should identify built-in types correctly"() {
-        expect:
-        PostgresTypeOperator.isBuiltInType(type) == expected
-
-        where:
-        type                  | expected
-        "int"                 | true
-        "text"                | true
-        "timestamp"           | true
-        "json"                | true
-        "uuid"                | true
-        "int[]"               | true
-        "custom_enum_type"    | false
-        "unknown_type"        | false
-        null                  | false
-    }
 } 

--- a/modules/excalibase-graphql-postgres/src/test/groovy/io/github/excalibase/postgres/util/PostgresArrayParameterHandlerTest.groovy
+++ b/modules/excalibase-graphql-postgres/src/test/groovy/io/github/excalibase/postgres/util/PostgresArrayParameterHandlerTest.groovy
@@ -1,0 +1,71 @@
+package io.github.excalibase.postgres.util
+
+import spock.lang.Specification
+
+class PostgresArrayParameterHandlerTest extends Specification {
+
+    def typeConverter = Mock(PostgresTypeConverter)
+    def paramHandler = new PostgresArrayParameterHandler(typeConverter)
+
+    def "should map BIT VARYING correctly and not confuse with CHARACTER VARYING"() {
+        expect: "BIT VARYING types should map to 'varbit'"
+        paramHandler.mapToPGArrayTypeName(baseType) == expectedMapping
+        
+        where:
+        baseType              | expectedMapping
+        "bit varying"         | "varbit"
+        "bit varying(20)"     | "varbit" 
+        "varbit"              | "varbit"
+        "varbit(16)"          | "varbit"
+        "BIT VARYING"         | "varbit"  // case insensitive
+        "VARBIT"              | "varbit"
+    }
+    
+    def "should map CHARACTER VARYING correctly and not confuse with BIT VARYING"() {
+        expect: "CHARACTER VARYING types should map to 'text'"
+        paramHandler.mapToPGArrayTypeName(baseType) == expectedMapping
+        
+        where:
+        baseType                   | expectedMapping
+        "character varying"        | "text"
+        "character varying(255)"   | "text"
+        "varchar"                  | "text"
+        "varchar(100)"             | "text"
+        "text"                     | "text"
+        "CHARACTER VARYING"        | "text"  // case insensitive
+        "VARCHAR"                  | "text"
+    }
+    
+    def "should not map CHARACTER VARYING as BIT type"() {
+        given: "various character varying type names"
+        def charVaryingTypes = [
+            "character varying",
+            "character varying(255)", 
+            "varchar",
+            "varchar(100)",
+            "text"
+        ]
+        
+        expect: "none should be mapped as varbit"
+        charVaryingTypes.every { type ->
+            paramHandler.mapToPGArrayTypeName(type) != "varbit"
+        }
+        
+        and: "all should be mapped as text"
+        charVaryingTypes.every { type ->
+            paramHandler.mapToPGArrayTypeName(type) == "text"
+        }
+    }
+    
+    def "should handle edge cases with 'varying' substring correctly"() {
+        expect: "only proper BIT VARYING types should map to varbit"
+        paramHandler.mapToPGArrayTypeName(baseType) == expectedMapping
+        
+        where:
+        baseType                      | expectedMapping
+        "varying"                     | "text"           // standalone 'varying' -> text default
+        "some_varying_field"          | "text"           // field containing 'varying' -> text default  
+        "bit varying"                 | "varbit"         // proper BIT VARYING -> varbit
+        "character varying"           | "text"           // proper CHARACTER VARYING -> text
+    }
+}

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/ColumnTypeConstant.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/constant/ColumnTypeConstant.java
@@ -142,44 +142,6 @@ public class ColumnTypeConstant {
     
     /** XML type */
     public static final String XML = "xml";
-    
-    // Type categories for getTypeCategory() method
-    
-    /** Integer type category */
-    public static final String CATEGORY_INTEGER = "integer";
-    
-    /** Numeric type category */
-    public static final String CATEGORY_NUMERIC = "numeric";
-    
-    /** Boolean type category */
-    public static final String CATEGORY_BOOLEAN = "boolean";
-    
-    /** Text type category */
-    public static final String CATEGORY_TEXT = "text";
-    
-    /** DateTime type category */
-    public static final String CATEGORY_DATETIME = "datetime";
-    
-    /** JSON type category */
-    public static final String CATEGORY_JSON = "json";
-    
-    /** UUID type category */
-    public static final String CATEGORY_UUID = "uuid";
-    
-    /** Network type category */
-    public static final String CATEGORY_NETWORK = "network";
-    
-    /** Bit type category */
-    public static final String CATEGORY_BIT = "bit";
-    
-    /** XML type category */
-    public static final String CATEGORY_XML = "xml";
-    
-    /** Array type category */
-    public static final String CATEGORY_ARRAY = "array";
-    
-    /** Unknown type category */
-    public static final String CATEGORY_UNKNOWN = "unknown";
 
     public static final String POSTGRES_ENUM = "postgres_enum";
     public static final String POSTGRES_COMPOSITE = "postgres_composite";

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -297,6 +297,48 @@ main() {
         "{ enhanced_types { id timestamptz_col timetz_col interval_col } }" \
         '.data.enhanced_types[0].timestamptz_col != null'
     
+    run_test "Enhanced Types - BIT Fields Query" \
+        "{ enhanced_types { id name bit_col varbit_col } }" \
+        '.data.enhanced_types[0].bit_col != null and .data.enhanced_types[0].varbit_col != null'
+    
+    # ==========================================
+    # BIT/VARBIT TYPES E2E TESTS (Production Validation)
+    # ==========================================
+    
+    echo ""
+    log_info "🔧 Starting BIT/VARBIT Type E2E Tests..."
+    echo ""
+    
+    # Test BIT type creation mutation
+    run_test "Create Enhanced Types with BIT values" \
+        "mutation { createEnhanced_types(input: { name: \"E2E BIT Test\", bit_col: \"10101010\", varbit_col: \"1100110011\", bit_array_col: [\"1010\", \"0101\", \"1111\"] }) { id name bit_col varbit_col } }" \
+        '.data.createEnhanced_types.name == "E2E BIT Test" and .data.createEnhanced_types.bit_col != null and .data.createEnhanced_types.varbit_col != null'
+    
+    # Test BIT type query and filtering
+    run_test "Query BIT Types with Filtering" \
+        "{ enhanced_types(where: { name: { eq: \"Test Record 1\" } }) { id name bit_col varbit_col } }" \
+        '.data.enhanced_types | length >= 1 and .[0].bit_col != null and .[0].varbit_col != null'
+    
+    # Test BIT type update mutation
+    run_test "Update BIT Type Fields" \
+        "mutation { updateEnhanced_types(input: { id: 1, bit_col: \"11110000\", varbit_col: \"0011001100\" }) { id bit_col varbit_col } }" \
+        '.data.updateEnhanced_types.id == 1 and .data.updateEnhanced_types.bit_col != null and .data.updateEnhanced_types.varbit_col != null'
+    
+    # Test BIT array operations (if arrays work properly)
+    run_test "Query BIT Array Fields" \
+        "{ enhanced_types(where: { name: { contains: \"BIT\" } }) { id name bit_array_col } }" \
+        '.data.enhanced_types | length >= 1'
+    
+    echo ""
+    log_info "✅ BIT/VARBIT Types E2E Testing Complete"
+    echo "  ✅ BIT(8) and VARBIT(16) field support"
+    echo "  ✅ BIT array field support (BIT(4)[])"  
+    echo "  ✅ Create mutations with BIT values"
+    echo "  ✅ Update mutations for BIT fields"
+    echo "  ✅ Query operations with BIT data"
+    echo "  ✅ Filtering by records containing BIT data"
+    echo ""
+    
     # ==========================================
     # CUSTOM TYPES TESTS (ENUMS & COMPOSITE)
     # ==========================================
@@ -736,6 +778,16 @@ main() {
     echo "  ✅ Address composite type (street, city, state, postal_code, country)"
     echo "  ✅ Mixed custom types in single mutations"
     echo "  ✅ Invalid enum value error handling"
+    echo ""
+    echo "🔧 PostgreSQL Advanced Types Coverage:"
+    echo "  ✅ JSON/JSONB types (direct objects and strings)"
+    echo "  ✅ Array types (integer[], text[], custom type arrays)"
+    echo "  ✅ Network types (inet, cidr, macaddr, macaddr8)"
+    echo "  ✅ Binary types (bytea)"
+    echo "  ✅ BIT/VARBIT types (bit(8), varbit(16), bit(4)[])"
+    echo "  ✅ Datetime types (timestamptz, timetz, interval)"
+    echo "  ✅ XML type"
+    echo "  ✅ UUID type"
     echo ""
     echo "🔒 Security Controls Coverage:"
     echo "  ✅ Query Depth Limiting (GraphQL.org security best practices)"

--- a/scripts/initdb.sql
+++ b/scripts/initdb.sql
@@ -197,6 +197,10 @@ CREATE TABLE IF NOT EXISTS enhanced_types (
     macaddr_col MACADDR,
     -- XML type
     xml_col XML,
+    -- BIT types
+    bit_col BIT(8),
+    varbit_col VARBIT(16),
+    bit_array_col BIT(4)[],
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -204,7 +208,8 @@ CREATE TABLE IF NOT EXISTS enhanced_types (
 INSERT INTO enhanced_types (
     id, name, json_col, jsonb_col, int_array, text_array,
     timestamptz_col, timetz_col, interval_col, numeric_col,
-    bytea_col, inet_col, cidr_col, macaddr_col, xml_col
+    bytea_col, inet_col, cidr_col, macaddr_col, xml_col,
+    bit_col, varbit_col, bit_array_col
 ) VALUES
 (1, 'Test Record 1', 
  '{"name": "John", "age": 30, "city": "New York"}',
@@ -219,7 +224,10 @@ INSERT INTO enhanced_types (
  '192.168.1.1',
  '192.168.0.0/24',
  '08:00:27:00:00:00',
- '<person><name>John</name><age>30</age></person>'
+ '<person><name>John</name><age>30</age></person>',
+ B'10101010',
+ B'1100110011',
+ '{1010,0101,1111}'
 ),
 (2, 'Test Record 2',
  '{"product": "laptop", "price": 1500, "specs": {"ram": "16GB", "cpu": "Intel i7"}}',
@@ -234,7 +242,10 @@ INSERT INTO enhanced_types (
  '10.0.0.1',
  '10.0.0.0/16',
  '00:1B:44:11:3A:B7',
- '<product><name>Laptop</name><price>1500</price></product>'
+ '<product><name>Laptop</name><price>1500</price></product>',
+ B'11110000',
+ B'101010',
+ '{0000,1111}'
 ),
 (3, 'Test Record 3',
  '{"company": "TechCorp", "employees": 500, "founded": 2010}',
@@ -249,7 +260,10 @@ INSERT INTO enhanced_types (
  '172.16.254.1',
  '172.16.0.0/12',
  '00:50:56:C0:00:01',
- '<company><name>TechCorp</name><industry>Software</industry></company>'
+ '<company><name>TechCorp</name><industry>Software</industry></company>',
+ NULL,
+ NULL,
+ NULL
 )
 ON CONFLICT (id) DO NOTHING;
 
@@ -607,6 +621,15 @@ BEGIN
     RAISE NOTICE '  - active_customers: % rows', (SELECT count(*) FROM active_customers);
     RAISE NOTICE '  - enhanced_types_summary: % rows', (SELECT count(*) FROM enhanced_types_summary);
     RAISE NOTICE '  - posts_with_authors: % rows', (SELECT count(*) FROM posts_with_authors);
+    RAISE NOTICE '';
+    RAISE NOTICE 'POSTGRESQL ADVANCED TYPES:';
+    RAISE NOTICE '  - JSON/JSONB: Full object support with enhanced scalar';
+    RAISE NOTICE '  - Arrays: INTEGER[], TEXT[], custom type arrays';
+    RAISE NOTICE '  - Network: INET, CIDR, MACADDR types';
+    RAISE NOTICE '  - Binary: BYTEA type';
+    RAISE NOTICE '  - BIT: BIT(8), VARBIT(16), BIT(4)[] arrays';
+    RAISE NOTICE '  - DateTime: TIMESTAMPTZ, TIMETZ, INTERVAL';
+    RAISE NOTICE '  - XML: Full XML data support';
     RAISE NOTICE '';
     RAISE NOTICE 'Schema: hana';
     RAISE NOTICE 'Ready for GraphQL API at port 10000';


### PR DESCRIPTION
  - Add BIT, VARBIT, and BIT array type handling in PostgresTypeOperator
  - Implement PostgresArrayParameterHandler support for BIT type arrays
  - Update schema generator to properly map BIT types to GraphQL strings
  - Add comprehensive test coverage including GraphQL mutations and queries
  - Enhance type checking methods and refactor hardcoded type constants