### PR TITLE
Security hardening: fail-closed auth, issuer validation, UPDATE WITH-CHECK RLS

### DIFF
--- a/.github/workflows/slack-pr-opened.yml
+++ b/.github/workflows/slack-pr-opened.yml
@@ -17,5 +17,5 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel: "${{ secrets.SLACK_CHANNEL_ID }}"
             text: ":eyes: *Review needed* — <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}> by ${{ github.event.pull_request.user.login }} in `${{ github.repository }}`"

--- a/.github/workflows/slack-pr-opened.yml
+++ b/.github/workflows/slack-pr-opened.yml
@@ -1,0 +1,21 @@
+name: Slack — PR opened
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  notify:
+    name: Post new PR to #team-prs
+    runs-on: ubuntu-latest
+    # Skip drafts — only ping once a PR is actually ready for review
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: ":eyes: *Review needed* — <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}> by ${{ github.event.pull_request.user.login }} in `${{ github.repository }}`"

--- a/.github/workflows/slack-pr-reviewed.yml
+++ b/.github/workflows/slack-pr-reviewed.yml
@@ -18,5 +18,5 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel: "${{ secrets.SLACK_CHANNEL_ID }}"
             text: ":white_check_mark: ${{ github.event.review.user.login }} *${{ github.event.review.state }}* — <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}>"

--- a/.github/workflows/slack-pr-reviewed.yml
+++ b/.github/workflows/slack-pr-reviewed.yml
@@ -1,0 +1,22 @@
+name: Slack — PR reviewed
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify:
+    name: Post review result to #team-prs
+    runs-on: ubuntu-latest
+    # review.state is one of: approved | changes_requested | commented.
+    # Skip plain "commented" reviews to cut noise; drop this line to post all.
+    if: github.event.review.state != 'commented'
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: ":white_check_mark: ${{ github.event.review.user.login }} *${{ github.event.review.state }}* — <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}>"

--- a/.github/workflows/slack-stale-pr-reminder.yml
+++ b/.github/workflows/slack-stale-pr-reminder.yml
@@ -35,5 +35,5 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel: "${{ secrets.SLACK_CHANNEL_ID }}"
             text: "*PRs still waiting for review in `${{ github.repository }}`:*\n${{ steps.prs.outputs.text }}"

--- a/.github/workflows/slack-stale-pr-reminder.yml
+++ b/.github/workflows/slack-stale-pr-reminder.yml
@@ -1,0 +1,39 @@
+name: Slack — stale PR reminder
+
+on:
+  schedule:
+    - cron: "0 2 * * 1-5"   # 09:00 ICT (UTC+7), Mon–Fri. cron is in UTC.
+  workflow_dispatch:          # allow manual runs from the Actions tab
+
+jobs:
+  remind:
+    name: Nudge unreviewed PRs in #team-prs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Find open PRs not yet approved
+        id: prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          msg=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --state open --json number,title,url,reviewDecision,isDraft \
+            --jq '[.[] | select(.isDraft == false and .reviewDecision != "APPROVED")]
+                   | map(":hourglass_flowing_sand: <\(.url)|#\(.number) \(.title)>")
+                   | join("\n")')
+          {
+            echo "text<<SLACK_EOF"
+            echo "$msg"
+            echo "SLACK_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post reminder to Slack
+        if: steps.prs.outputs.text != ''
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "*PRs still waiting for review in `${{ github.repository }}`:*\n${{ steps.prs.outputs.text }}"

--- a/docs/features/user-context-rls.md
+++ b/docs/features/user-context-rls.md
@@ -139,7 +139,7 @@ Any OIDC-compatible provider that exposes a `/.well-known/jwks.json` (or equival
 - **excalibase-auth** — lightweight companion auth service
 - **Auth0** — `https://your-tenant.auth0.com/.well-known/jwks.json`
 - **Keycloak** — `https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs`
-- **Supabase** — configured via JWKS URL
+- **OIDC providers** — configured via JWKS URL
 - **Any OIDC provider** — point `auth.jwks-url` at the JWKS endpoint
 
 ## Security Notes

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/CorsConfig.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/CorsConfig.java
@@ -5,18 +5,44 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${app.cors.allowed-origins:*}")
+    /**
+     * Allowed cross-origin origins for {@code /graphql}. Defaults to empty —
+     * cross-origin requests are denied unless an operator sets
+     * {@code APP_CORS_ALLOWED_ORIGINS} (e.g. {@code https://app.example.com}).
+     * A wildcard ({@code *}) must be opted into explicitly; it is no longer the
+     * default, so a fresh deploy is not open to every origin.
+     */
+    @Value("${app.cors.allowed-origins:}")
     private String allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] origins = parseOrigins(allowedOrigins);
+        if (origins.length == 0) {
+            // No origins configured: register no cross-origin mapping at all, so
+            // the browser's default same-origin policy applies (deny by default).
+            return;
+        }
         registry.addMapping("/graphql")
-                .allowedOrigins(allowedOrigins.split(","))
+                .allowedOrigins(origins)
                 .allowedMethods("POST", "GET", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false);
+    }
+
+    /** Splits the comma-separated origins, dropping blank entries. */
+    private static String[] parseOrigins(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return new String[0];
+        }
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toArray(String[]::new);
     }
 }

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/JwtSecurityConfig.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/JwtSecurityConfig.java
@@ -44,11 +44,13 @@ public class JwtSecurityConfig {
                     "jwt-enabled=true requires app.security.auth.jwks-url or app.security.auth.hmac-secret");
         }
 
+        String expectedIssuer = auth.expectedIssuerOrDefault();
+
         if (hasJwks) {
-            return new JwtService(auth.jwksUrl(), ttlMinutes);
+            return new JwtService(auth.jwksUrl(), ttlMinutes, expectedIssuer);
         }
 
-        return new JwtService(auth.hmacSecret());
+        return new JwtService(auth.hmacSecret(), expectedIssuer);
     }
 
     /**

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/JwtSecurityConfig.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/JwtSecurityConfig.java
@@ -9,6 +9,9 @@ import io.github.excalibase.security.JwtAuthFilter;
 import io.github.excalibase.security.JwtService;
 import io.github.excalibase.security.PostgresRoleResolver;
 import io.github.excalibase.service.VaultCredentialService;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -20,6 +23,32 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "app.security.jwt-enabled", havingValue = "true")
 @EnableConfigurationProperties(SecurityProperties.class)
 public class JwtSecurityConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtSecurityConfig.class);
+
+    private final SecurityProperties securityProperties;
+
+    public JwtSecurityConfig(SecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    /**
+     * Warns when JWT auth is on but no multi-tenant provisioning URL is set:
+     * every authenticated user then shares one datasource, so there is NO
+     * row-level isolation between users unless RLS policies are authored. This
+     * is a soft warning, not a failure — single-datasource + RLS is a valid
+     * deployment, but an operator must opt into it knowingly.
+     */
+    @PostConstruct
+    void warnIfSingleDatasourceWithoutIsolation() {
+        boolean multiTenant = securityProperties != null
+                && securityProperties.isMultiTenantEnabled();
+        if (!multiTenant) {
+            log.warn("app.security.jwt-enabled=true but app.security.multi-tenant.provisioning-url "
+                    + "is not configured: multi-user single-datasource mode has no row-level "
+                    + "isolation between users unless RLS policies are authored.");
+        }
+    }
 
     @Bean
     public JwtService jwtService(

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityConfig.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityConfig.java
@@ -1,22 +1,78 @@
 package io.github.excalibase.config;
 
 import io.github.excalibase.security.JwtAuthFilter;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
+    private final boolean jwtEnabled;
+    private final String provisioningUrl;
+
+    public SecurityConfig(
+            @Value("${app.security.jwt-enabled:false}") boolean jwtEnabled,
+            @Value("${app.security.multi-tenant.provisioning-url:}") String provisioningUrl) {
+        this.jwtEnabled = jwtEnabled;
+        this.provisioningUrl = provisioningUrl;
+    }
+
+    /**
+     * Fail fast at startup when the app is configured for multi-tenant / provisioning
+     * but JWT auth is disabled. A multi-tenant deployment must never run
+     * unauthenticated — without JWT there is no tenant claim to route or isolate on.
+     */
+    @PostConstruct
+    void validateMultiTenantRequiresJwt() {
+        boolean multiTenant = provisioningUrl != null && !provisioningUrl.isBlank();
+        if (multiTenant && !jwtEnabled) {
+            throw new IllegalStateException(
+                    "app.security.multi-tenant.provisioning-url is set but app.security.jwt-enabled=false — "
+                            + "a multi-tenant deployment must run with JWT authentication enabled. "
+                            + "Set app.security.jwt-enabled=true.");
+        }
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
                                            @Autowired(required = false) JwtAuthFilter jwtAuthFilter) throws Exception {
         // CSRF disabled — stateless JWT API, no session cookies, Bearer-token auth only
-        http.csrf(csrf -> csrf.disable()) // NOSONAR
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        http.csrf(csrf -> csrf.disable()); // NOSONAR
+
+        if (jwtEnabled) {
+            // Fail-closed: with JWT enabled, every request must carry a verified token.
+            // JwtAuthFilter authenticates the request; requests with no/invalid token
+            // are rejected here (401) instead of falling through to permitAll.
+            //
+            // WebSocket upgrade endpoints are exempt from this HTTP rule because their
+            // auth is enforced in their own layer: JwtHandshakeInterceptor (header path)
+            // and the handlers' connection_init + subscribe guards (browser path, which
+            // cannot set an Authorization header on the upgrade). Actuator health/info
+            // probes stay open for liveness/readiness.
+            http.authorizeHttpRequests(auth -> auth
+                    // WS upgrades are HTTP GET (browsers can't set Authorization on the
+                    // upgrade); the GraphQL/REST data APIs are POST and must be authenticated.
+                    .requestMatchers(HttpMethod.GET, "/graphql", "/api/v1/realtime").permitAll()
+                    .requestMatchers("/actuator/health/**", "/actuator/info").permitAll()
+                    .anyRequest().authenticated());
+            // Stateless Bearer-token API: a missing/anonymous credential is 401
+            // (Unauthorized), not the framework default of 403, so clients know to
+            // present a token.
+            http.exceptionHandling(ex -> ex.authenticationEntryPoint(
+                    new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
+        } else {
+            // Single-tenant / standalone: permissive by design.
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        }
 
         if (jwtAuthFilter != null) {
             http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityProperties.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityProperties.java
@@ -38,6 +38,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = "app.security")
 public record SecurityProperties(
         boolean jwtEnabled,
+        boolean verboseErrors,
         Auth auth,
         MultiTenant multiTenant,
         Postgres postgres

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityProperties.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/SecurityProperties.java
@@ -46,7 +46,8 @@ public record SecurityProperties(
     public record Auth(
             String jwksUrl,
             String hmacSecret,
-            String jwksTtlMinutes
+            String jwksTtlMinutes,
+            String expectedIssuer
     ) {
         public boolean hasJwksUrl() {
             return jwksUrl != null && !jwksUrl.isBlank();
@@ -54,6 +55,14 @@ public record SecurityProperties(
 
         public boolean hasHmacSecret() {
             return hmacSecret != null && !hmacSecret.isBlank();
+        }
+
+        /**
+         * Expected JWT {@code iss} claim. Defaults to {@code "excalibase"} (matching the
+         * auth service) when not configured. Set to blank to opt out of issuer validation.
+         */
+        public String expectedIssuerOrDefault() {
+            return expectedIssuer == null ? "excalibase" : expectedIssuer;
         }
     }
 

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/datasource/DataSourceConfig.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/datasource/DataSourceConfig.java
@@ -1,6 +1,7 @@
 package io.github.excalibase.config.datasource;
 
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.excalibase.config.SecurityProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -23,7 +24,7 @@ import java.util.Map;
  * gracefully until a live DataSource is available (or after a schema reload).
  */
 @Configuration
-@EnableConfigurationProperties(DataSourceProperties.class)
+@EnableConfigurationProperties({DataSourceProperties.class, SecurityProperties.class})
 public class DataSourceConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DataSourceConfig.class);

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/GraphQLWebSocketHandler.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/GraphQLWebSocketHandler.java
@@ -175,7 +175,7 @@ public class GraphQLWebSocketHandler extends TextWebSocketHandler implements Sub
 
     @SuppressWarnings("unchecked")
     private String extractBearerToken(Map<String, Object> payload) {
-        // Accept both payload.Authorization and payload.headers.Authorization (Hasura + Apollo conventions)
+        // Accept both payload.Authorization and payload.headers.Authorization (Apollo and common conventions)
         Object direct = payload.get("Authorization");
         if (direct == null) {
             Object headers = payload.get("headers");

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/GraphQLWebSocketHandler.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/GraphQLWebSocketHandler.java
@@ -232,6 +232,13 @@ public class GraphQLWebSocketHandler extends TextWebSocketHandler implements Sub
         String fieldName = extracted[1];
 
         String tenantId = (String) session.getAttributes().get(SESSION_TENANT_KEY);
+        // Fail-closed: when JWT is enabled, an unauthenticated session (no verified
+        // tenant) may not subscribe. Single-tenant deploys (jwt-disabled) stay
+        // permissive by design.
+        if (jwtEnabled && tenantId == null) {
+            sendError(session, id, "Unauthenticated: send connection_init with Authorization first");
+            return;
+        }
         log.info("Starting subscription '{}' for tenant '{}' table '{}' (field: '{}'), session {}",
                 id, tenantId, tableName, fieldName, session.getId());
 

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/RealtimeWebSocketHandler.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/config/ws/RealtimeWebSocketHandler.java
@@ -136,7 +136,10 @@ public class RealtimeWebSocketHandler extends TextWebSocketHandler {
         if (existing != null) existing.dispose();
 
         String tenantId = (String) session.getAttributes().get(GraphQLWebSocketHandler.SESSION_TENANT_KEY);
-        if (jwtEnabled && wsAuthRequired && tenantId == null) {
+        // Fail-closed: when JWT is enabled, an unauthenticated session (no verified
+        // tenant) may not subscribe — regardless of tenant-in-subject. Single-tenant
+        // deploys (jwt-disabled) stay permissive by design.
+        if (jwtEnabled && tenantId == null) {
             sendError(session, id, "Unauthenticated: send connection_init with Authorization first");
             return;
         }

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/controller/GraphqlController.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/controller/GraphqlController.java
@@ -3,12 +3,14 @@ package io.github.excalibase.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.excalibase.compiler.SqlCompiler;
 import io.github.excalibase.config.GraphQLObservabilityInstrumentation;
+import io.github.excalibase.config.SecurityProperties;
 import io.github.excalibase.schema.GraphqlSchemaManager;
 import io.github.excalibase.security.JwtAuthFilter;
 import io.github.excalibase.security.JwtClaims;
 import io.github.excalibase.security.RoleNotAllowedException;
 import io.github.excalibase.service.QueryExecutionService;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -36,13 +38,16 @@ public class GraphqlController {
     private final GraphqlSchemaManager schemaManager;
     private final QueryExecutionService queryExecutor;
     private final GraphQLObservabilityInstrumentation observability;
+    private final boolean verboseErrors;
 
     public GraphqlController(GraphqlSchemaManager schemaManager,
                              QueryExecutionService queryExecutor,
-                             GraphQLObservabilityInstrumentation observability) {
+                             GraphQLObservabilityInstrumentation observability,
+                             @Nullable SecurityProperties securityProperties) {
         this.schemaManager = schemaManager;
         this.queryExecutor = queryExecutor;
         this.observability = observability;
+        this.verboseErrors = securityProperties != null && securityProperties.verboseErrors();
     }
 
     @PostMapping("/graphql")
@@ -81,7 +86,7 @@ public class GraphqlController {
             } catch (Exception e) {
                 log.warn("GraphQL request failed", e);
                 return ResponseEntity.ok(Map.of(
-                        "errors", List.of(Map.of("message", extractErrorMessage(e)))));
+                        "errors", List.of(Map.of("message", clientErrorMessage(e)))));
             }
         });
     }
@@ -119,6 +124,21 @@ public class GraphqlController {
             return queryExecutor.executeTwoPhase(compiled, params, state.mutationExecutor());
         }
         return queryExecutor.executeQuery(compiled, params);
+    }
+
+    /**
+     * Message surfaced to the client for a failed request. The full detail is
+     * always logged server-side (see the catch block). By default
+     * ({@code app.security.verbose-errors=false}) clients get a generic message
+     * so raw database errors — column, type, and constraint names — never leak
+     * and can't be used as a schema-probing oracle. Operators may set
+     * {@code verbose-errors=true} in dev to keep the detailed message.
+     */
+    private String clientErrorMessage(Exception e) {
+        if (verboseErrors) {
+            return extractErrorMessage(e);
+        }
+        return "query execution error";
     }
 
     private static String extractErrorMessage(Exception e) {

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/rls/EngineRowCheckContributor.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/rls/EngineRowCheckContributor.java
@@ -30,6 +30,11 @@ public final class EngineRowCheckContributor implements RowCheckContributor {
         return enforcer.permitsRow(projectId, tableName, claims, toOperation(op), row);
     }
 
+    @Override
+    public boolean permitsUpdate(String tableName, Map<String, Object> changedColumns) {
+        return enforcer.permitsRowUpdate(projectId, tableName, claims, changedColumns);
+    }
+
     private static Operation toOperation(RlsOp op) {
         return switch (op) {
             case SELECT -> Operation.SELECT;

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/rls/RlsPolicyEnforcer.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/rls/RlsPolicyEnforcer.java
@@ -80,6 +80,20 @@ public final class RlsPolicyEnforcer {
     }
 
     /**
+     * WITH-CHECK for an UPDATE's partial new image: {@code changedRow} carries
+     * only the columns the caller is setting. Returns {@code true} iff those
+     * changes keep the row within the project's UPDATE policies (or no UPDATE
+     * policy targets the table), {@code false} if the update must be rejected —
+     * e.g. moving an ownership/tenant column out of policy. Unchanged columns
+     * are not re-validated here; the UPDATE's USING predicate already did.
+     */
+    public boolean permitsRowUpdate(String projectId, String table, JwtClaims claims,
+                                    java.util.Map<String, Object> changedRow) {
+        return new RowMatcher(policyProvider.policiesFor(projectId))
+                .matchesUpdate(table, changedRow, context(projectId, claims));
+    }
+
+    /**
      * Applies column masking to an already-fetched row in place — the non-SQL
      * path used by realtime fan-out, where rows arrive from CDC rather than a
      * SELECT. Hidden columns are removed and NULL-masked columns nulled, per the

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/security/JwtAuthFilter.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/security/JwtAuthFilter.java
@@ -11,9 +11,13 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 public class JwtAuthFilter extends OncePerRequestFilter {
 
@@ -60,6 +64,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             RoleContext.setRole(resolvedRole);
         }
 
+        // Populate the Spring Security context so authorization rules
+        // (anyRequest().authenticated() when jwt-enabled) accept verified tokens
+        // and reject requests that carry none. A null claims means no/blank
+        // Authorization header — left unauthenticated so the filter chain's rule
+        // decides (permitAll for single-tenant, 401 for jwt-enabled).
+        if (claims != null) {
+            setAuthentication(claims, resolvedRole);
+        }
+
         try {
             applyTenantContext(claims);
             applyRlsContext(claims);
@@ -68,7 +81,18 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             RlsContext.clear();
             RoleContext.clear();
             clearTenantContext(claims);
+            SecurityContextHolder.clearContext();
         }
+    }
+
+    private static void setAuthentication(JwtClaims claims, String resolvedRole) {
+        String principal = claims.userId() != null ? claims.userId() : claims.email();
+        List<? extends org.springframework.security.core.GrantedAuthority> authorities =
+                resolvedRole != null
+                        ? AuthorityUtils.createAuthorityList("ROLE_" + resolvedRole.toUpperCase())
+                        : AuthorityUtils.NO_AUTHORITIES;
+        var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     /**

--- a/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/security/JwtService.java
+++ b/modules/excalibase-graphql-api/src/main/java/io/github/excalibase/security/JwtService.java
@@ -40,15 +40,25 @@ public class JwtService {
     // HMAC mode
     private final byte[] hmacSecret;
 
+    // Expected token issuer (iss). When null/blank, issuer validation is skipped
+    // so deployments that never set an issuer keep working unchanged.
+    private final String expectedIssuer;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
 
     /** JWKS mode — fetches EC public keys from the given URL, caches with TTL. */
     public JwtService(String jwksUrl, int ttlMinutes) {
+        this(jwksUrl, ttlMinutes, null);
+    }
+
+    /** JWKS mode with an expected issuer. {@code expectedIssuer} may be null/blank to skip iss validation. */
+    public JwtService(String jwksUrl, int ttlMinutes, String expectedIssuer) {
         this.jwksUrl = jwksUrl;
         this.keyCache = new TTLCache<>(Duration.ofMinutes(ttlMinutes));
         this.hmacSecret = null;
+        this.expectedIssuer = blankToNull(expectedIssuer);
 
         try {
             keyCache.put(CACHE_KEY, fetchKeys());
@@ -60,21 +70,37 @@ public class JwtService {
 
     /** HMAC mode — verifies HS256 tokens using the given secret. */
     public JwtService(String hmacSecret) {
+        this(hmacSecret, (String) null);
+    }
+
+    /** HMAC mode with an expected issuer. {@code expectedIssuer} may be null/blank to skip iss validation. */
+    public JwtService(String hmacSecret, String expectedIssuer) {
         if (hmacSecret == null || hmacSecret.length() < 32) {
             throw new IllegalStateException("app.security.auth.hmac-secret must be at least 32 characters");
         }
         this.hmacSecret = hmacSecret.getBytes(StandardCharsets.UTF_8);
         this.jwksUrl = null;
         this.keyCache = null;
+        this.expectedIssuer = blankToNull(expectedIssuer);
         log.info("jwt_service_mode=hmac");
     }
 
     /** Test constructor — inject EC key directly, no remote fetch. */
     public JwtService(ECPublicKey publicKey) {
+        this(publicKey, null);
+    }
+
+    /** Test constructor with an expected issuer — inject EC key directly, no remote fetch. */
+    public JwtService(ECPublicKey publicKey, String expectedIssuer) {
         this.jwksUrl = "test";
         this.keyCache = new TTLCache<>(Duration.ofHours(24));
         this.keyCache.put(CACHE_KEY, List.of(publicKey));
         this.hmacSecret = null;
+        this.expectedIssuer = blankToNull(expectedIssuer);
+    }
+
+    private static String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
     }
 
     // -------------------------------------------------------------------------
@@ -92,6 +118,13 @@ public class JwtService {
             }
 
             JWTClaimsSet claims = jwt.getJWTClaimsSet();
+
+            // Validate issuer (iss) against the configured expected issuer. Skipped
+            // when no expected issuer is configured so existing deployments that
+            // never set one keep working.
+            if (expectedIssuer != null && !expectedIssuer.equals(claims.getIssuer())) {
+                throw new JwtVerificationException("JWT issuer mismatch");
+            }
 
             // Require exp claim for user session tokens; API-key tokens (scope=api-key) may omit.
             Date expiration = claims.getExpirationTime();

--- a/modules/excalibase-graphql-api/src/main/resources/application.yaml
+++ b/modules/excalibase-graphql-api/src/main/resources/application.yaml
@@ -70,7 +70,7 @@ app:
   schemas: ${APP_SCHEMAS:public}
   database-type: postgres
   max-rows: 30
-  max-query-depth: 0
+  max-query-depth: 10  # Reject GraphQL queries nested deeper than this (DoS guard). 0 disables.
   cache:
     schema-ttl-minutes: 30  # Schema cache TTL in minutes (default: 30 minutes)
     role-privileges-ttl-minutes: 30  # Role privileges cache TTL in minutes (default: 30 minutes)
@@ -90,16 +90,9 @@ app:
     subject-prefix: cdc  # Subject prefix (events on cdc.{schema}.{table})
     tenant-in-subject: false  # When true, subject shape is cdc.{tenantId}.{schema}.{table} (multi-tenant)
 
-# GraphQL Security Configuration - Production Defaults
-# Based on GraphQL.org security recommendations and OWASP guidelines
-graphql:
-  security:
-    max-query-depth: 20       # Prevent deeply nested queries (default: 20)
-    max-query-complexity: 10000 # Prevent expensive operations (default: 1000)
-    max-query-tokens: 5000    # Prevent parser DoS (default: 5000)
-    max-query-characters: 50000 # 50KB query size limit (default: 50KB)
-    max-whitespace-tokens: 10000
-    max-rule-depth: 50
+# NOTE: The former `graphql.security:` block was removed — it had no
+# @ConfigurationProperties binding and was never read (dead config). The active
+# query-depth guard is `app.max-query-depth` above, enforced in SqlCompiler.
 logging:
   level:
     root: ${log.level.root:info}

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/JwtRlsIntegrationTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/JwtRlsIntegrationTest.java
@@ -147,13 +147,13 @@ class JwtRlsIntegrationTest {
 
     @Test
     @Order(3)
-    void noJwt_noUnauthorized() throws Exception {
-        // Without JWT, the controller no longer blocks with 401
-        // RLS protects the data at the DB level (returns 0 rows or errors when user_id unset)
+    void noJwt_returns401() throws Exception {
+        // Fail-closed: with jwt-enabled=true a request carrying no token is rejected
+        // at the security layer (401) rather than passing through unauthenticated.
         mockMvc.perform(post("/graphql")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(graphql("{ testRlsOrders { id product total } }")))
-                .andExpect(status().isOk()); // no 401 — authorization is DB-enforced via RLS
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/MultiTenantIntegrationTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/MultiTenantIntegrationTest.java
@@ -149,6 +149,9 @@ class MultiTenantIntegrationTest {
     registry.add("app.database-type", () -> "postgres");
     registry.add("app.max-rows", () -> 30);
     registry.add("app.security.jwt-enabled", () -> "true");
+    // Surface the underlying fail-closed message ("Database not available") to
+    // the client so this test can assert on it; production defaults to false.
+    registry.add("app.security.verbose-errors", () -> "true");
     registry.add("app.security.auth.jwks-url", () -> "http://localhost:" + mockVaultPort + "/.well-known/jwks.json");
     registry.add("app.security.multi-tenant.provisioning-url", () -> "http://localhost:" + mockVaultPort + "/api");
     registry.add("app.security.multi-tenant.provisioning-pat", () -> "test-pat-token");

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/MultiTenantIntegrationTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/MultiTenantIntegrationTest.java
@@ -187,14 +187,15 @@ class MultiTenantIntegrationTest {
 
   @Test
   @Order(1)
-  @DisplayName("No JWT → 200 with default datasource (no 401, no tenant routing)")
-  void noJwt_usesDefaultDatasource() throws Exception {
-    // Without JWT, no tenant routing — uses default Spring datasource
-    // Returns 200 (no 401); the RLS/tenant enforcement is handled by the DB, not the controller
+  @DisplayName("No JWT → 401 (fail-closed; multi-tenant must be authenticated)")
+  void noJwt_returns401() throws Exception {
+    // Fail-closed: a multi-tenant deployment (jwt-enabled=true) must reject
+    // unauthenticated requests at the security layer rather than silently
+    // serving the default datasource.
     mockMvc.perform(post("/graphql")
             .contentType(MediaType.APPLICATION_JSON)
             .content(graphql("{ tenantProducts { id name price } }")))
-        .andExpect(status().isOk());
+        .andExpect(status().isUnauthorized());
   }
 
   // ─── Multi-Tenant Routing ────────────────────────────────────────────────────

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/SqlCompilerIntegrationTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/SqlCompilerIntegrationTest.java
@@ -269,7 +269,7 @@ class SqlCompilerIntegrationTest {
     @Test
     @Order(36)
     void nestedInsert_orderWithItems() throws Exception {
-        // Hasura-style: create order + order_items in one mutation
+        // Nested insert: create order + order_items in one mutation
         mockMvc.perform(post("/graphql")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(graphql("""

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/CorsConfigTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/CorsConfigTest.java
@@ -1,0 +1,64 @@
+package io.github.excalibase.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the CORS default is deny-by-default: no allowed-origins value means
+ * no cross-origin mapping is registered, while an explicit value is honoured.
+ */
+class CorsConfigTest {
+
+    /** Exposes the otherwise-protected registered CORS configurations. */
+    private static final class ProbeRegistry extends CorsRegistry {
+        @Override
+        protected Map<String, CorsConfiguration> getCorsConfigurations() {
+            return super.getCorsConfigurations();
+        }
+    }
+
+    private Map<String, CorsConfiguration> configsFor(String allowedOrigins) {
+        CorsConfig config = new CorsConfig();
+        ReflectionTestUtils.setField(config, "allowedOrigins", allowedOrigins);
+        ProbeRegistry registry = new ProbeRegistry();
+        config.addCorsMappings(registry);
+        return registry.getCorsConfigurations();
+    }
+
+    @Test
+    @DisplayName("empty allowed-origins → no cross-origin mapping registered (deny by default)")
+    void emptyOrigins_noMapping() {
+        assertThat(configsFor("")).doesNotContainKey("/graphql");
+    }
+
+    @Test
+    @DisplayName("blank/whitespace allowed-origins → no cross-origin mapping")
+    void blankOrigins_noMapping() {
+        assertThat(configsFor("   ")).doesNotContainKey("/graphql");
+    }
+
+    @Test
+    @DisplayName("explicit origin → mapping registered with that origin only")
+    void explicitOrigin_mappingRegistered() {
+        Map<String, CorsConfiguration> configs = configsFor("https://app.example.com");
+        assertThat(configs).containsKey("/graphql");
+        assertThat(configs.get("/graphql").getAllowedOrigins())
+                .containsExactly("https://app.example.com");
+    }
+
+    @Test
+    @DisplayName("multiple comma-separated origins → all registered, blanks dropped")
+    void multipleOrigins_allRegistered() {
+        Map<String, CorsConfiguration> configs =
+                configsFor("https://a.example.com, https://b.example.com, ");
+        assertThat(configs.get("/graphql").getAllowedOrigins())
+                .containsExactly("https://a.example.com", "https://b.example.com");
+    }
+}

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/SecurityConfigTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/SecurityConfigTest.java
@@ -1,0 +1,48 @@
+package io.github.excalibase.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the startup guard in {@link SecurityConfig}: a multi-tenant /
+ * provisioning deployment must not run with JWT authentication disabled.
+ */
+class SecurityConfigTest {
+
+    @Test
+    @DisplayName("provisioning-url set + jwt-enabled=false → fails fast at startup")
+    void multiTenantWithoutJwt_failsFast() {
+        SecurityConfig config = new SecurityConfig(false, "http://provisioning:24005/api");
+
+        assertThatThrownBy(config::validateMultiTenantRequiresJwt)
+                .isInstanceOf(IllegalStateException.class)
+                .satisfies(ex -> assertThat(ex.getMessage().toLowerCase())
+                        .contains("jwt-enabled")
+                        .contains("multi-tenant"));
+    }
+
+    @Test
+    @DisplayName("provisioning-url set + jwt-enabled=true → starts cleanly")
+    void multiTenantWithJwt_ok() {
+        SecurityConfig config = new SecurityConfig(true, "http://provisioning:24005/api");
+        assertThatCode(config::validateMultiTenantRequiresJwt).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("no provisioning-url + jwt-enabled=false → single-tenant stays permissive")
+    void singleTenantWithoutJwt_ok() {
+        SecurityConfig config = new SecurityConfig(false, "");
+        assertThatCode(config::validateMultiTenantRequiresJwt).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("no provisioning-url + jwt-enabled=true → ok")
+    void singleTenantWithJwt_ok() {
+        SecurityConfig config = new SecurityConfig(true, null);
+        assertThatCode(config::validateMultiTenantRequiresJwt).doesNotThrowAnyException();
+    }
+}

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/ws/RealtimeWebSocketHandlerTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/config/ws/RealtimeWebSocketHandlerTest.java
@@ -210,6 +210,31 @@ class RealtimeWebSocketHandlerTest {
     }
 
     @Test
+    @DisplayName("jwt-enabled + no authenticated tenant → subscribe rejected as unauthenticated")
+    void jwtEnabled_nullTenant_subscribeRejected() throws Exception {
+        // Fail-closed: when jwt-enabled=true, a session with no verified tenant must
+        // not be allowed to subscribe — independent of tenant-in-subject.
+        var field = RealtimeWebSocketHandler.class.getDeclaredField("jwtEnabled");
+        field.setAccessible(true);
+        field.setBoolean(handler, true);
+
+        var sent = new ArrayList<String>();
+        WebSocketSession session = session(sent);
+        handler.afterConnectionEstablished(session);
+
+        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(Map.of(
+                "type", "subscribe", "id", "s1", "collection", "customers"))));
+
+        // No event must be delivered (no subscription created); an error is returned.
+        subscriptionService.publish(null, new CDCEvent("INSERT", "public", "customers", "{}", 0L));
+
+        assertThat(sent).hasSize(1);
+        var err = mapper.readTree(sent.getFirst());
+        assertThat(err.get("type").asText()).isEqualTo("error");
+        assertThat(err.get("message").asText().toLowerCase()).contains("unauthenticated");
+    }
+
+    @Test
     @DisplayName("subscribe without id or collection returns error")
     void missingFields_error() throws Exception {
         var sent = new ArrayList<String>();

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/controller/GraphqlControllerErrorTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/controller/GraphqlControllerErrorTest.java
@@ -1,0 +1,78 @@
+package io.github.excalibase.controller;
+
+import io.github.excalibase.config.GraphQLObservabilityInstrumentation;
+import io.github.excalibase.config.SecurityProperties;
+import io.github.excalibase.schema.GraphqlSchemaManager;
+import io.github.excalibase.service.QueryExecutionService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that raw database error detail is gated behind
+ * {@code app.security.verbose-errors}: clients get a generic message by default
+ * and the detailed message only when an operator opts in.
+ */
+class GraphqlControllerErrorTest {
+
+    private static final String LEAKY_DETAIL =
+            "ERROR: column \"secret_ssn\" does not exist; constraint users_pkey";
+
+    private GraphqlController controllerWithVerbose(boolean verbose) {
+        GraphqlSchemaManager schemaManager = mock(GraphqlSchemaManager.class);
+        QueryExecutionService queryExecutor = mock(QueryExecutionService.class);
+        GraphQLObservabilityInstrumentation observability = mock(GraphQLObservabilityInstrumentation.class);
+
+        // The query path explodes with a leaky DB-style message.
+        when(schemaManager.resolveEngineState(any()))
+                .thenThrow(new RuntimeException(LEAKY_DETAIL));
+        // observe() simply runs the supplied action.
+        when(observability.observe(any(), any(), any())).thenAnswer(inv -> {
+            Supplier<ResponseEntity<Object>> action = inv.getArgument(2);
+            return action.get();
+        });
+
+        SecurityProperties props = new SecurityProperties(true, verbose, null, null, null);
+        return new GraphqlController(schemaManager, queryExecutor, observability, props);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String messageOf(ResponseEntity<Object> response) {
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) body.get("errors");
+        return (String) errors.get(0).get("message");
+    }
+
+    @Test
+    @DisplayName("verbose-errors=false → client sees a generic message, not the DB detail")
+    void verboseFalse_genericMessage() {
+        GraphqlController controller = controllerWithVerbose(false);
+        ResponseEntity<Object> response =
+                controller.graphql(Map.of("query", "{ users { id } }"), mock(HttpServletRequest.class));
+
+        String message = messageOf(response);
+        assertThat(message).isEqualTo("query execution error");
+        assertThat(message).doesNotContain("secret_ssn");
+        assertThat(message).doesNotContain("ERROR:");
+    }
+
+    @Test
+    @DisplayName("verbose-errors=true → client sees the detailed DB message")
+    void verboseTrue_detailedMessage() {
+        GraphqlController controller = controllerWithVerbose(true);
+        ResponseEntity<Object> response =
+                controller.graphql(Map.of("query", "{ users { id } }"), mock(HttpServletRequest.class));
+
+        assertThat(messageOf(response)).contains("secret_ssn");
+    }
+}

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/rls/RlsPolicyEnforcerTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/rls/RlsPolicyEnforcerTest.java
@@ -126,6 +126,50 @@ class RlsPolicyEnforcerTest {
         assertThat(projection.selectList()).hasSize(2);
     }
 
+    private static Policy ownerUpdate(String resource) {
+        return new Policy(
+                "upd-" + resource, "owner-upd-" + resource, resource,
+                PolicyEffect.ALLOW, java.util.Set.of(Operation.UPDATE), LogicOperator.AND, 0, true,
+                List.of(new Rule("user_id", FieldType.UUID, RuleOperator.EQ, "{{currentUserId}}")),
+                List.of(Assignment.all()));
+    }
+
+    @Test
+    @DisplayName("permitsRowUpdate: reassigning owner column to another user is rejected")
+    void permitsRowUpdate_reassignOwner_rejected() {
+        var enforcer = enforcerWith("proj-a", List.of(ownerUpdate("orders")));
+        boolean ok = enforcer.permitsRowUpdate("proj-a", "orders", claims(ALICE, "proj-a"),
+                java.util.Map.of("user_id", "22222222-2222-2222-2222-222222222222"));
+        assertThat(ok).isFalse();
+    }
+
+    @Test
+    @DisplayName("permitsRowUpdate: setting owner column to self is permitted")
+    void permitsRowUpdate_keepOwner_permitted() {
+        var enforcer = enforcerWith("proj-a", List.of(ownerUpdate("orders")));
+        boolean ok = enforcer.permitsRowUpdate("proj-a", "orders", claims(ALICE, "proj-a"),
+                java.util.Map.of("user_id", ALICE));
+        assertThat(ok).isTrue();
+    }
+
+    @Test
+    @DisplayName("permitsRowUpdate: partial update not touching the policy column is permitted")
+    void permitsRowUpdate_untouchedPolicyColumn_permitted() {
+        var enforcer = enforcerWith("proj-a", List.of(ownerUpdate("orders")));
+        boolean ok = enforcer.permitsRowUpdate("proj-a", "orders", claims(ALICE, "proj-a"),
+                java.util.Map.of("title", "renamed"));
+        assertThat(ok).isTrue();
+    }
+
+    @Test
+    @DisplayName("permitsRowUpdate: no UPDATE policy → permissive")
+    void permitsRowUpdate_noPolicy_permissive() {
+        var enforcer = new RlsPolicyEnforcer(new InMemoryPolicyProvider());
+        boolean ok = enforcer.permitsRowUpdate("proj-a", "orders", claims(ALICE, "proj-a"),
+                java.util.Map.of("user_id", "22222222-2222-2222-2222-222222222222"));
+        assertThat(ok).isTrue();
+    }
+
     @Test
     @DisplayName("operation is honored — INSERT-only policy doesn't filter a SELECT")
     void operationHonored() {

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/JwtAuthFilterRoleContextTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/JwtAuthFilterRoleContextTest.java
@@ -52,7 +52,7 @@ class JwtAuthFilterRoleContextTest {
     }
 
     private static SecurityProperties propsWithRoleSwitching() {
-        return new SecurityProperties(true, null, null,
+        return new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/JwtServiceTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/JwtServiceTest.java
@@ -169,6 +169,54 @@ class JwtServiceTest {
         assertThrows(JwtVerificationException.class, () -> jwtService.verify("not.a.jwt"));
     }
 
+    // ─── Issuer Validation ───────────────────────────────────────────────────────
+
+    private String signJwtWithIssuer(String issuer) throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject("alice@test.com")
+                .claim("userId", 1L)
+                .claim("projectId", "p")
+                .claim("role", "user")
+                .issuer(issuer)
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+                .build();
+        SignedJWT signed = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).build(), claims);
+        signed.sign(new ECDSASigner(privateKey));
+        return signed.serialize();
+    }
+
+    @Test
+    @DisplayName("verify rejects a token whose iss does not match the expected issuer")
+    void wrongIssuer_throws() throws Exception {
+        JwtService svc = new JwtService(publicKey, "excalibase");
+        String token = signJwtWithIssuer("evil-issuer");
+
+        JwtVerificationException ex = assertThrows(JwtVerificationException.class,
+                () -> svc.verify(token));
+        assertTrue(ex.getMessage().toLowerCase().contains("issuer"));
+    }
+
+    @Test
+    @DisplayName("verify accepts a token whose iss matches the expected issuer")
+    void matchingIssuer_passes() throws Exception {
+        JwtService svc = new JwtService(publicKey, "excalibase");
+        String token = signJwtWithIssuer("excalibase");
+
+        JwtClaims claims = svc.verify(token);
+        assertEquals("1", claims.userId());
+    }
+
+    @Test
+    @DisplayName("verify skips issuer validation when no expected issuer is configured")
+    void noExpectedIssuer_skipsValidation() throws Exception {
+        JwtService svc = new JwtService(publicKey, null);
+        String token = signJwtWithIssuer("anything-goes");
+
+        JwtClaims claims = svc.verify(token);
+        assertEquals("1", claims.userId());
+    }
+
     // ─── Public Key Cache Tests ──────────────────────────────────────────────────
 
     @Nested

--- a/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/PostgresRoleResolverTest.java
+++ b/modules/excalibase-graphql-api/src/test/java/io/github/excalibase/security/PostgresRoleResolverTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PostgresRoleResolverTest {
 
     private static SecurityProperties enabled(List<String> allowedRoles) {
-        return new SecurityProperties(true, null, null,
+        return new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",
@@ -29,7 +29,7 @@ class PostgresRoleResolverTest {
     }
 
     private static SecurityProperties disabled() {
-        return new SecurityProperties(true, null, null, null);
+        return new SecurityProperties(true, false, null, null, null);
     }
 
     private static JwtClaims claims(String scope, String role) {
@@ -47,7 +47,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_disabledFeature_blankAnonRole_returnsNull() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "  ",  // blank → disabled
@@ -125,7 +125,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_authenticatedScope_nullAllowlist_customRoleThrows() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon", "app_authenticated", "app_service", null)));
@@ -161,7 +161,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_malformedAnonRole_throws() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "drop-table; --",  // malformed identifier — still triggers feature (non-blank)
@@ -176,7 +176,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_malformedAuthenticatedDefaultRole_throws() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",
@@ -191,7 +191,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_blankServiceRole_thrownAsConfigError() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",
@@ -207,7 +207,7 @@ class PostgresRoleResolverTest {
 
     @Test
     void resolve_blankAuthenticatedDefaultRole_thrownAsConfigError() {
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",
@@ -225,7 +225,7 @@ class PostgresRoleResolverTest {
     void resolve_allowlistedRoleStillValidatedForSafety() {
         // Even an allowlisted role must pass the SAFE_ROLE_NAME check — defense in depth
         // against an operator who copy-pastes a hostile string into config.
-        var properties = new SecurityProperties(true, null, null,
+        var properties = new SecurityProperties(true, false, null, null,
                 new SecurityProperties.Postgres(
                         new SecurityProperties.Postgres.RoleSwitching(
                                 "app_anon",

--- a/modules/excalibase-graphql-api/src/test/resources/application-mysql-test.yaml
+++ b/modules/excalibase-graphql-api/src/test/resources/application-mysql-test.yaml
@@ -12,18 +12,10 @@ spring:
 app:
   allowed-schema: testdb
   database-type: MySQL
+  max-query-depth: 0   # disabled in tests; production defaults to 10
   security:
   nats:
     enabled: false
-
-graphql:
-  security:
-    max-query-depth: 10
-    max-query-complexity: 1000
-    max-query-tokens: 5000
-    max-query-characters: 50000
-    max-whitespace-tokens: 5000
-    max-rule-depth: 30
 
 spring.graphql:
   graphiql:

--- a/modules/excalibase-graphql-api/src/test/resources/application-test.yaml
+++ b/modules/excalibase-graphql-api/src/test/resources/application-test.yaml
@@ -13,17 +13,8 @@ spring:
 app:
   allowed-schema: public
   database-type: postgres
+  max-query-depth: 0   # disabled in tests (some E2E queries nest deeply); production defaults to 10
   security:
-
-# GraphQL Security Configuration for Testing
-graphql:
-  security:
-    max-query-depth: 8        # Lower limit for testing deep queries
-    max-query-complexity: 500  # Lower limit for testing complexity
-    max-query-tokens: 2000    # Lower limit for testing token limits
-    max-query-characters: 10000  # 10KB limit for testing
-    max-whitespace-tokens: 5000
-    max-rule-depth: 30
 
 logging:
   level:

--- a/modules/excalibase-graphql-mysql/src/main/java/io/github/excalibase/mysql/MysqlMutationCompiler.java
+++ b/modules/excalibase-graphql-mysql/src/main/java/io/github/excalibase/mysql/MysqlMutationCompiler.java
@@ -135,6 +135,7 @@ public class MysqlMutationCompiler implements MutationCompiler {
         if (inputArg == null) return null;
 
         Map<String, Object> inputFields = shared.extractObjectFields(inputArg.getValue(), variables);
+        requireUpdateAllowed(tableName, inputFields);
         String alias = shared.dialect().randAlias();
         String objectSql = shared.queryBuilder().buildObject(field.getSelectionSet(), tableName, alias);
 
@@ -189,6 +190,20 @@ public class MysqlMutationCompiler implements MutationCompiler {
         if (check != null && !check.permits(tableName, row, RlsOp.INSERT)) {
             throw new RlsViolationException(
                     "Row violates row-level security policy for INSERT on " + tableName);
+        }
+    }
+
+    /**
+     * Rejects an UPDATE whose new image (the SET columns) would move the row out
+     * of the caller's UPDATE policies — the WITH-CHECK half for updates. A no-op
+     * when no row-check contributor is registered or no UPDATE policy governs a
+     * changed column.
+     */
+    private void requireUpdateAllowed(String tableName, Map<String, Object> changedColumns) {
+        RowCheckContributor check = RlsContext.rowCheck();
+        if (check != null && !check.permitsUpdate(tableName, changedColumns)) {
+            throw new RlsViolationException(
+                    "Row violates row-level security policy for UPDATE on " + tableName);
         }
     }
 }

--- a/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/PostgresMutationCompiler.java
+++ b/modules/excalibase-graphql-postgres/src/main/java/io/github/excalibase/postgres/PostgresMutationCompiler.java
@@ -267,6 +267,7 @@ public class PostgresMutationCompiler implements MutationCompiler {
         if (inputArg == null) return null;
 
         Map<String, Object> inputFields = shared.extractObjectFields(inputArg.getValue(), variables);
+        requireUpdateAllowed(tableName, inputFields);
         String alias = shared.dialect().randAlias();
         String objectSql = shared.queryBuilder().buildObject(field.getSelectionSet(), tableName, alias);
 
@@ -305,6 +306,7 @@ public class PostgresMutationCompiler implements MutationCompiler {
         if (setArg == null) return null;
 
         Map<String, Object> setFields = shared.extractObjectFields(setArg.getValue(), variables);
+        requireUpdateAllowed(tableName, setFields);
         String alias = shared.dialect().randAlias();
         String objectSql = shared.queryBuilder().buildObject(field.getSelectionSet(), tableName, alias);
 
@@ -358,6 +360,20 @@ public class PostgresMutationCompiler implements MutationCompiler {
         if (check != null && !check.permits(tableName, row, RlsOp.INSERT)) {
             throw new RlsViolationException(
                     "Row violates row-level security policy for INSERT on " + tableName);
+        }
+    }
+
+    /**
+     * Rejects an UPDATE whose new image (the SET columns) would move the row out
+     * of the caller's UPDATE policies — the WITH-CHECK half for updates. A no-op
+     * when no row-check contributor is registered (feature off / no JWT) or when
+     * no UPDATE policy governs a changed column.
+     */
+    private void requireUpdateAllowed(String tableName, Map<String, Object> changedColumns) {
+        RowCheckContributor check = RlsContext.rowCheck();
+        if (check != null && !check.permitsUpdate(tableName, changedColumns)) {
+            throw new RlsViolationException(
+                    "Row violates row-level security policy for UPDATE on " + tableName);
         }
     }
 

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/compiler/QueryBuilder.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/compiler/QueryBuilder.java
@@ -56,7 +56,7 @@ public class QueryBuilder {
         String objectSql = buildObject(field.getSelectionSet(), tableName, alias, params);
 
         // Parse distinctOn argument
-        List<String> distinctOnCols = parseDistinctOn(field);
+        List<String> distinctOnCols = parseDistinctOn(field, tableName);
 
         // Parse vector argument (k-NN search). When present, it takes precedence
         // over user-supplied orderBy and limit — the embedding similarity order
@@ -149,7 +149,7 @@ public class QueryBuilder {
         return vectorSearchBuilder.build(ov, alias, schemaInfo, params);
     }
 
-    private List<String> parseDistinctOn(Field field) {
+    private List<String> parseDistinctOn(Field field, String tableName) {
         List<String> cols = new ArrayList<>();
         for (Argument arg : field.getArguments()) {
             if (ARG_DISTINCT_ON.equals(arg.getName()) && arg.getValue() instanceof ArrayValue av) {
@@ -160,7 +160,27 @@ public class QueryBuilder {
                 }
             }
         }
+        validateDistinctOnColumns(cols, tableName);
         return cols;
+    }
+
+    /**
+     * Rejects distinctOn entries that are not real columns of the table before
+     * they reach {@code quoteIdentifier}. Without this, an unknown name is quoted
+     * and spliced into the SQL, turning the database error into an oracle that
+     * echoes arbitrary attacker strings. Skipped only when the table's column set
+     * is unknown (no introspected metadata), to preserve existing behaviour.
+     */
+    private void validateDistinctOnColumns(List<String> cols, String tableName) {
+        if (cols.isEmpty()) return;
+        Set<String> known = schemaInfo.getColumns(tableName);
+        if (known.isEmpty()) return;
+        for (String col : cols) {
+            if (!known.contains(col)) {
+                throw new IllegalArgumentException(
+                        "Unknown column in distinctOn for table " + tableName + ": " + col);
+            }
+        }
     }
 
     // === Aggregates ===

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/introspection/ArrRelInsertFactory.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/schema/introspection/ArrRelInsertFactory.java
@@ -13,7 +13,7 @@ import static io.github.excalibase.schema.GraphqlConstants.CREATE_INPUT_SUFFIX;
 
 /**
  * Builds the nested-insert wrapper input objects (one per unique child
- * type referenced via a reverse FK) used to drive Hasura-style
+ * type referenced via a reverse FK) used to drive nested
  * {@code data: [ChildCreateInput]} mutations.
  *
  * <p>The produced {@code TypeArrRelInsertInput} types reference the

--- a/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/security/RowCheckContributor.java
+++ b/modules/excalibase-graphql-starter/src/main/java/io/github/excalibase/security/RowCheckContributor.java
@@ -22,4 +22,20 @@ public interface RowCheckContributor {
      *         this resource/op); {@code false} if it must be rejected
      */
     boolean permits(String tableName, Map<String, Object> row, RlsOp op);
+
+    /**
+     * WITH-CHECK for an UPDATE's partial new image: {@code changedColumns} holds
+     * only the columns the mutation is setting. Returns {@code false} when those
+     * changes would move the row out of the caller's UPDATE policies (e.g.
+     * reassigning an ownership column), in which case the mutation must be
+     * rejected before any SQL runs. Returns {@code true} when no UPDATE policy
+     * governs a changed column, preserving the engine's permissive default.
+     *
+     * <p>Default-implemented over {@link #permits} so existing contributors keep
+     * compiling; the engine-backed implementation overrides it with new-image
+     * semantics that do not falsely reject untouched policy columns.
+     */
+    default boolean permitsUpdate(String tableName, Map<String, Object> changedColumns) {
+        return permits(tableName, changedColumns, RlsOp.UPDATE);
+    }
 }

--- a/modules/excalibase-graphql-starter/src/test/java/io/github/excalibase/QueryDepthLimitTest.java
+++ b/modules/excalibase-graphql-starter/src/test/java/io/github/excalibase/QueryDepthLimitTest.java
@@ -1,0 +1,108 @@
+package io.github.excalibase;
+
+import io.github.excalibase.compiler.MutationBuilder;
+import io.github.excalibase.compiler.SqlCompiler;
+import io.github.excalibase.schema.SchemaInfo;
+import io.github.excalibase.spi.MutationCompiler;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the GraphQL query-depth guard (app.max-query-depth → SqlCompiler maxDepth).
+ *
+ * <p>A self-referential FK (employee.manager_id → employee.id) lets a query nest
+ * arbitrarily deep via the forward-FK field, so we can build queries just under and
+ * just over the configured limit.
+ */
+class QueryDepthLimitTest {
+
+    private static final SqlDialect testDialect = new TestDialect();
+
+    private SchemaInfo selfReferentialSchema() {
+        SchemaInfo info = new SchemaInfo();
+        info.addColumn("employee", "id", "integer");
+        info.addColumn("employee", "name", "varchar");
+        info.addColumn("employee", "manager_id", "integer");
+        info.addPrimaryKey("employee", "id");
+        info.setTableSchema("employee", "public");
+        // forward FK field: managerId → employee
+        info.addForeignKey("employee", "manager_id", "employee", "id");
+        return info;
+    }
+
+    /** Build "{ employee { name managerId { name managerId { ... } } } }" with the given nesting. */
+    private String nestedQuery(int managerLevels) {
+        StringBuilder sb = new StringBuilder("{ employee { name");
+        for (int i = 0; i < managerLevels; i++) {
+            sb.append(" managerId { name");
+        }
+        sb.append(" }".repeat(managerLevels));
+        sb.append(" } }");
+        return sb.toString();
+    }
+
+    @Test
+    void maxDepthZero_disablesEnforcement() {
+        SqlCompiler compiler = new SqlCompiler(selfReferentialSchema(), "public", 30,
+                testDialect, new NoOpMutationCompiler(), 0);
+        // Deeply nested query compiles fine when the guard is disabled.
+        assertNotNull(compiler.compile(nestedQuery(10)));
+    }
+
+    @Test
+    void queryWithinDepthLimit_compiles() {
+        SqlCompiler compiler = new SqlCompiler(selfReferentialSchema(), "public", 30,
+                testDialect, new NoOpMutationCompiler(), 5);
+        // A shallow query (well under the limit of 5) must compile.
+        assertNotNull(compiler.compile(nestedQuery(1)));
+    }
+
+    @Test
+    void queryExceedingDepthLimit_isRejected() {
+        int limit = 3;
+        SqlCompiler compiler = new SqlCompiler(selfReferentialSchema(), "public", 30,
+                testDialect, new NoOpMutationCompiler(), limit);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> compiler.compile(nestedQuery(10)));
+        assertTrue(ex.getMessage().contains("exceeds maximum allowed depth of " + limit),
+                "Expected depth-limit message, got: " + ex.getMessage());
+    }
+
+    // === Helpers ===
+
+    private static class NoOpMutationCompiler implements MutationCompiler {
+        @Override
+        public SqlCompiler.CompiledQuery compileMutation(
+                graphql.language.Field field, String fieldName,
+                java.util.Map<String, Object> params,
+                java.util.Map<String, Object> variables,
+                MutationBuilder shared) {
+            return null;
+        }
+    }
+
+    private static class TestDialect implements SqlDialect {
+        @Override public String buildObject(List<String> pairs) {
+            return "jsonb_build_object(" + String.join(", ", pairs) + ")";
+        }
+        @Override public String aggregateArray(String expr) { return "jsonb_agg(" + expr + ")"; }
+        @Override public String coalesceArray(String expr) { return "coalesce(" + expr + ", '[]'::jsonb)"; }
+        @Override public String quoteIdentifier(String id) { return "\"" + id + "\""; }
+        @Override public String qualifiedTable(String schema, String table) {
+            return schema + ".\"" + table + "\"";
+        }
+        @Override public String encodeCursor(String expr) { return "encode(" + expr + ")"; }
+        @Override public String ilike(String col, String param) { return col + " ILIKE " + param; }
+        @Override public String orderByNulls(String col, String dir, String nulls) { return col + " " + dir; }
+        @Override public String suffixCast(String type) { return ""; }
+        @Override public String onConflict(List<String> cols, List<String> sets) { return ""; }
+        @Override public boolean supportsReturning() { return true; }
+        @Override public String cteName(String alias, String suffix) { return "\"" + alias + "_" + suffix + "\""; }
+        @Override public String randAlias() { return "\"t" + System.nanoTime() % 10000 + "\""; }
+        @Override public String distinctOn(List<String> cols, String alias) { return ""; }
+    }
+}

--- a/modules/excalibase-graphql-starter/src/test/java/io/github/excalibase/compiler/DistinctOnValidationTest.java
+++ b/modules/excalibase-graphql-starter/src/test/java/io/github/excalibase/compiler/DistinctOnValidationTest.java
@@ -1,0 +1,106 @@
+package io.github.excalibase.compiler;
+
+import io.github.excalibase.SqlDialect;
+import io.github.excalibase.schema.SchemaInfo;
+import io.github.excalibase.spi.MutationCompiler;
+import graphql.language.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Guards distinctOn column validation: only real columns may flow into the
+ * SQL, so an unknown name is rejected rather than quoted and echoed back as an
+ * error oracle.
+ */
+class DistinctOnValidationTest {
+
+    private SchemaInfo schemaInfo;
+    private SqlCompiler compiler;
+
+    @BeforeEach
+    void setUp() {
+        schemaInfo = new SchemaInfo();
+        schemaInfo.addColumn("users", "id", "integer");
+        schemaInfo.addColumn("users", "name", "varchar");
+        schemaInfo.addColumn("users", "email", "varchar");
+        schemaInfo.addPrimaryKey("users", "id");
+        compiler = new SqlCompiler(schemaInfo, "public", 30, new TestDialect(), new NoOpMutationCompiler());
+    }
+
+    @Test
+    @DisplayName("distinctOn on a real column compiles successfully")
+    void knownColumn_compiles() {
+        SqlCompiler.CompiledQuery result =
+                compiler.compile("{ users(distinctOn: [\"name\"]) { id name } }");
+        assertThat(result).isNotNull();
+        assertThat(result.sql()).contains("\"users\"");
+    }
+
+    @Test
+    @DisplayName("distinctOn on an unknown column throws IllegalArgumentException")
+    void unknownColumn_throws() {
+        assertThatThrownBy(() ->
+                compiler.compile("{ users(distinctOn: [\"' OR 1=1 --\"]) { id name } }"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown column in distinctOn");
+    }
+
+    @Test
+    @DisplayName("distinctOn mixing a real and an unknown column is rejected")
+    void mixedKnownAndUnknown_throws() {
+        assertThatThrownBy(() ->
+                compiler.compile("{ users(distinctOn: [\"name\", \"bogus\"]) { id name } }"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bogus");
+    }
+
+    /** Postgres-like quoting dialect, sufficient for compileList. */
+    private static final class TestDialect implements SqlDialect {
+        @Override public String buildObject(List<String> pairs) {
+            return "jsonb_build_object(" + String.join(", ", pairs) + ")";
+        }
+        @Override public String aggregateArray(String expr) { return "jsonb_agg(" + expr + ")"; }
+        @Override public String coalesceArray(String expr) { return "coalesce(" + expr + ", '[]'::jsonb)"; }
+        @Override public String quoteIdentifier(String id) { return "\"" + id + "\""; }
+        @Override public String qualifiedTable(String schema, String table) {
+            return schema + ".\"" + table + "\"";
+        }
+        @Override public String encodeCursor(String expr) { return "encode(" + expr + ")"; }
+        @Override public String ilike(String col, String param) { return col + " ILIKE " + param; }
+        @Override public String orderByNulls(String col, String dir, String nulls) { return col + " " + dir; }
+        @Override public String suffixCast(String type) { return ""; }
+        @Override public String onConflict(List<String> cols, List<String> sets) { return ""; }
+        @Override public boolean supportsReturning() { return true; }
+        @Override public String cteName(String alias, String suffix) { return "\"" + alias + "_" + suffix + "\""; }
+        @Override public String randAlias() { return "\"t" + System.nanoTime() % 10000 + "\""; }
+        @Override public String distinctOn(List<String> cols, String alias) {
+            StringBuilder sb = new StringBuilder("DISTINCT ON (");
+            for (int i = 0; i < cols.size(); i++) {
+                if (i > 0) sb.append(", ");
+                sb.append(alias).append(".\"").append(cols.get(i)).append("\"");
+            }
+            return sb.append(")").toString();
+        }
+    }
+
+    /** Mutation compiler that does nothing — this test only exercises queries. */
+    private static final class NoOpMutationCompiler implements MutationCompiler {
+        @Override
+        public SqlCompiler.CompiledQuery compileMutation(Field field, String fieldName,
+                Map<String, Object> params, Map<String, Object> variables, MutationBuilder shared) {
+            return null;
+        }
+        @Override
+        public SqlCompiler.CompiledQuery compileMutationFragment(Field field, String fieldName,
+                Map<String, Object> params, Map<String, Object> variables, MutationBuilder shared) {
+            return null;
+        }
+    }
+}

--- a/modules/excalibase-rls-core/src/main/java/io/github/excalibase/rls/MaskMode.java
+++ b/modules/excalibase-rls-core/src/main/java/io/github/excalibase/rls/MaskMode.java
@@ -9,7 +9,7 @@ package io.github.excalibase.rls;
  * SQL emission and Java fallback for each.
  */
 public enum MaskMode {
-    /** Column is omitted from the result entirely (Hasura-style). */
+    /** Column is omitted from the result entirely. */
     HIDE,
     /** Column value is replaced with null. */
     NULL,

--- a/modules/excalibase-rls-core/src/main/java/io/github/excalibase/rls/RowMatcher.java
+++ b/modules/excalibase-rls-core/src/main/java/io/github/excalibase/rls/RowMatcher.java
@@ -47,6 +47,85 @@ public class RowMatcher {
     }
 
     /**
+     * WITH-CHECK for an UPDATE's partial new image — {@code changedRow} holds
+     * only the columns the caller is setting, not the full post-update row.
+     *
+     * <p>Native RLS evaluates WITH-CHECK over the complete new row; here we only
+     * have the changed columns, so we enforce the half we can prove: a changed
+     * column whose new value violates a policy is rejected. Rules that reference
+     * columns the caller did not touch are treated as still satisfied, because
+     * the UPDATE's USING predicate already validated the pre-update row for
+     * those columns — this keeps legitimate partial updates working while still
+     * blocking the real attack (reassigning an ownership/tenant column out of
+     * policy). DENY policies veto on any changed value they match.
+     *
+     * @return {@code true} if the changed image is permitted (or no UPDATE
+     *         policy exists for the resource); {@code false} if it must be rejected
+     */
+    public boolean matchesUpdate(String resource, Map<String, Object> changedRow, UserContext ctx) {
+        VariableResolver resolver = new VariableResolver(ctx);
+        List<Policy> applicable = inScope(resource, ctx, Operation.UPDATE);
+
+        for (Policy p : applicable) {
+            if (p.effect() == PolicyEffect.DENY
+                    && referencesAnyChangedColumn(p, changedRow)
+                    && matchesPresentRules(p, changedRow, resolver)) {
+                return false;
+            }
+        }
+
+        if (!rlsEnabledFor(resource, Operation.UPDATE)) return true;
+
+        // The new image is permitted unless a changed column it actually sets
+        // violates every ALLOW policy that governs that column. An ALLOW that
+        // does not reference any changed column imposes no constraint here (its
+        // columns are unchanged and already validated by USING).
+        boolean anyAllowGovernsChange = false;
+        for (Policy p : applicable) {
+            if (p.effect() != PolicyEffect.ALLOW) continue;
+            if (!referencesAnyChangedColumn(p, changedRow)) continue;
+            anyAllowGovernsChange = true;
+            if (matchesPresentRules(p, changedRow, resolver)) return true;
+        }
+        return !anyAllowGovernsChange;
+    }
+
+    /** True if any of the policy's rules targets a column present in {@code changedRow}. */
+    private static boolean referencesAnyChangedColumn(Policy policy, Map<String, Object> changedRow) {
+        for (Rule r : policy.rules()) {
+            if (changedRow.containsKey(rootField(r.field()))) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Evaluates only the rules whose field is present in {@code changedRow},
+     * honouring the policy's AND/OR logic. Rules on absent (unchanged) columns
+     * are skipped — they are validated by the UPDATE's USING predicate, not here.
+     */
+    private static boolean matchesPresentRules(Policy policy, Map<String, Object> changedRow, VariableResolver resolver) {
+        List<Rule> present = policy.rules().stream()
+                .filter(r -> changedRow.containsKey(rootField(r.field())))
+                .toList();
+        if (present.isEmpty()) return true;
+        if (policy.ruleLogic() == LogicOperator.AND) {
+            for (Rule r : present) {
+                if (!matchesRule(r, changedRow, resolver)) return false;
+            }
+            return true;
+        }
+        for (Rule r : present) {
+            if (matchesRule(r, changedRow, resolver)) return true;
+        }
+        return false;
+    }
+
+    private static String rootField(String field) {
+        int dot = field.indexOf('.');
+        return dot < 0 ? field : field.substring(0, dot);
+    }
+
+    /**
      * True iff at least one enabled ALLOW policy targets this resource and
      * declares this operation in its {@code operations} set. The "RLS is on"
      * test from RFC 0001's composition rule; computed without reference to the

--- a/modules/excalibase-rls-core/src/test/java/io/github/excalibase/rls/RowMatcherAnonAndDefaultDenyTest.java
+++ b/modules/excalibase-rls-core/src/test/java/io/github/excalibase/rls/RowMatcherAnonAndDefaultDenyTest.java
@@ -72,7 +72,7 @@ class RowMatcherAnonAndDefaultDenyTest {
     @Test
     @DisplayName("anon CAN see rows when an ALLOW assigned to 'anon' grants it explicitly")
     void anon_allowed_whenPolicyExplicitlyTargetsAnon() {
-        // The way to give anon read access (mirroring Supabase's "public_posts" pattern):
+        // The way to give anon read access (the public-read pattern):
         // an explicit ALLOW assigned to the "anon" role with the row condition.
         Policy publicReadable = new Policy(
             UUID.randomUUID().toString(), "public posts readable by anon", "posts",

--- a/modules/excalibase-rls-core/src/test/java/io/github/excalibase/rls/RowMatcherTest.java
+++ b/modules/excalibase-rls-core/src/test/java/io/github/excalibase/rls/RowMatcherTest.java
@@ -210,6 +210,68 @@ class RowMatcherTest {
         }
     }
 
+    @Nested
+    @DisplayName("UPDATE WITH-CHECK (partial new-image)")
+    class UpdateWithCheck {
+
+        private Policy ownerUpdateAllow() {
+            return policyBuilder()
+                .name("owner update")
+                .resource("orders")
+                .effect(PolicyEffect.ALLOW)
+                .operations(Set.of(Operation.UPDATE))
+                .rules(new Rule("user_id", FieldType.UUID, RuleOperator.EQ, "{{currentUserId}}"))
+                .assignments(Assignment.all())
+                .build();
+        }
+
+        @Test
+        @DisplayName("no policies → any changed image is permitted")
+        void noPolicies_permitted() {
+            RowMatcher matcher = new RowMatcher(List.of());
+            assertThat(matcher.matchesUpdate("orders", Map.of("user_id", BOB.toString()), alice)).isTrue();
+        }
+
+        @Test
+        @DisplayName("changing a policy column to a violating value → rejected")
+        void changesPolicyColumnToViolatingValue_rejected() {
+            RowMatcher matcher = new RowMatcher(List.of(ownerUpdateAllow()));
+            // Alice tries to reassign her order to Bob — escapes her own visibility
+            assertThat(matcher.matchesUpdate("orders", Map.of("user_id", BOB.toString()), alice)).isFalse();
+        }
+
+        @Test
+        @DisplayName("changing a policy column to a compliant value → permitted")
+        void changesPolicyColumnToCompliantValue_permitted() {
+            RowMatcher matcher = new RowMatcher(List.of(ownerUpdateAllow()));
+            assertThat(matcher.matchesUpdate("orders", Map.of("user_id", ALICE.toString()), alice)).isTrue();
+        }
+
+        @Test
+        @DisplayName("partial update that does NOT touch the policy column → permitted (USING already validated the row)")
+        void doesNotTouchPolicyColumn_permitted() {
+            RowMatcher matcher = new RowMatcher(List.of(ownerUpdateAllow()));
+            // Only changing a non-policy column; absent user_id must not be treated as a violation
+            assertThat(matcher.matchesUpdate("orders", Map.of("title", "renamed"), alice)).isTrue();
+        }
+
+        @Test
+        @DisplayName("DENY matching a changed value vetoes the update")
+        void denyMatchingChangedValue_vetoes() {
+            Policy hideDrafts = policyBuilder()
+                .name("hide drafts")
+                .resource("orders")
+                .effect(PolicyEffect.DENY)
+                .operations(Set.of(Operation.UPDATE))
+                .rules(new Rule("status", FieldType.STRING, RuleOperator.EQ, "draft"))
+                .assignments(Assignment.all())
+                .build();
+            RowMatcher matcher = new RowMatcher(List.of(ownerUpdateAllow(), hideDrafts));
+            assertThat(matcher.matchesUpdate("orders",
+                Map.of("user_id", ALICE.toString(), "status", "draft"), alice)).isFalse();
+        }
+    }
+
     // ---------- helpers ----------
 
     private static UserContext userContext(UUID userId, UUID tenantId, Set<String> roles) {


### PR DESCRIPTION
## Summary

Security hardening + row/column-level security (RLS/CLS) engine for the multi-tenant GraphQL API, plus realtime/WebSocket resilience and Helm multi-pod support.

## Security hardening (fail-closed)

- Fail-closed JWT/multi-tenant defaults; startup guard requires JWT when multi-tenant is enabled
- JWT issuer validation (`iss` mismatch now rejected)
- WebSocket subscribe requires a tenant when JWT is enabled (both realtime + graphql-ws handlers)
- `anyRequest().authenticated()` when JWT is enabled; CORS deny-by-default
- UPDATE WITH-CHECK RLS enforcement (closes a cross-tenant write gap on UPDATE)
- `distinctOn` column validation; verbose errors gated behind config

## RLS / CLS engine

- Query-first RLS on single-table SELECT via WHERE contributor
- Operation-aware RLS on UPDATE/DELETE + INSERT/UPDATE WITH-CHECK via RowMatcher
- RLS threaded into nested FK sub-selects (multi-table embeds)
- Column-level security: HIDE/NULL masking + per-subscriber masking on realtime CDC events
- Dialect-aware identifier quoting (RLS/CLS on MySQL via backticks)
- Vendored as reactor modules so CI builds the engine from source

## Realtime + infra

- WebSocket heartbeat + serialized sends to survive idle proxies
- Helm: Gateway API, graceful rollout, PDB, WS heartbeat for multi-pod
- CI: Slack notifications for PR open/review/stale

## Validation

- API test suite green; RLS integration tests passing
- Local AIO e2e validated: IDOR→403, SSRF blocked, JWT projectId binding, cross-project replay→401, rate-limit→429

19 commits · 125 files · +7376/-189
